### PR TITLE
Doppler MCP Server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Run TypeScript compilation
+        run: pnpm run build
+
+      - name: Test CLI help
+        run: node dist/index.js --help

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 node_modules
+dist
+doppler-openapi.json
+
+# pnpm
+.pnpm-store
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,237 @@
+# Doppler MCP Server
+
+MCP (Model Context Protocol) server that provides AI assistants with access to the Doppler API for secrets management.
+
+## Quick Start
+
+Add to your MCP client configuration (e.g., Claude Desktop):
+
+```json
+{
+  "mcpServers": {
+    "doppler": {
+      "command": "npx",
+      "args": ["-y", "@dopplerhq/mcp-server"],
+      "env": {
+        "DOPPLER_TOKEN": "<your-doppler-token>"
+      }
+    }
+  }
+}
+```
+
+See [Service Tokens](https://docs.doppler.com/docs/service-tokens) to create a token.
+
+### Alternative: CLI Authentication (No Token in Config)
+
+If you have the [Doppler CLI](https://docs.doppler.com/docs/cli) installed, you can use your CLI session instead of a service token. This keeps credentials out of your config file entirely.
+
+**Prerequisites:**
+
+1. Install the Doppler CLI
+2. Run `doppler login` (creates a global/root session stored in your OS keychain)
+3. Create a Doppler project to store your `DOPPLER_TOKEN` for the MCP server
+
+**Configuration:**
+
+```json
+{
+  "mcpServers": {
+    "doppler": {
+      "command": "doppler",
+      "args": [
+        "run",
+        "--project",
+        "mcp-server-tokens",
+        "--config",
+        "dev",
+        "--",
+        "npx",
+        "-y",
+        "@dopplerhq/mcp-server",
+        "--project",
+        "my-app",
+        "--read-only"
+      ]
+    }
+  }
+}
+```
+
+**How it works:**
+
+- `doppler run --project mcp-server-tokens --config dev` fetches secrets (including `DOPPLER_TOKEN`) from the specified Doppler project and injects them as environment variables
+- The MCP server receives `DOPPLER_TOKEN` and uses it to access the Doppler API
+- `--project my-app --read-only` on the MCP server scopes what the LLM can access
+
+**Two levels of scoping:**
+
+| Level                            | Controls                              | Example                                                    |
+| -------------------------------- | ------------------------------------- | ---------------------------------------------------------- |
+| `doppler run --project/--config` | Which token the MCP server uses       | `mcp-server-tokens/dev` contains `DOPPLER_TOKEN=dp.st.xxx` |
+| MCP server `--project/--config`  | What the LLM can access via the token | Restrict to `my-app/production`                            |
+
+This pattern is ideal for local development where you don't want any tokens in config files.
+
+## CLI Options
+
+```
+--read-only        Only expose read operations (GET endpoints)
+--project <name>   Override auto-detected project
+--config <name>    Override auto-detected config
+--verbose, -v      Enable verbose logging to stderr
+-h, --help         Show help message
+```
+
+### Examples
+
+**Read-only mode**
+
+```json
+{
+  "mcpServers": {
+    "doppler": {
+      "command": "npx",
+      "args": ["-y", "@dopplerhq/mcp-server", "--read-only"],
+      "env": { "DOPPLER_TOKEN": "dp.pt.xxx" }
+    }
+  }
+}
+```
+
+**Restrict to a specific project**:
+
+```json
+{
+  "mcpServers": {
+    "doppler": {
+      "command": "npx",
+      "args": ["-y", "@dopplerhq/mcp-server", "--project", "my-app"],
+      "env": { "DOPPLER_TOKEN": "dp.pt.xxx" }
+    }
+  }
+}
+```
+
+**Restrict to a specific config**:
+
+```json
+{
+  "mcpServers": {
+    "doppler": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@dopplerhq/mcp-server",
+        "--project",
+        "my-app",
+        "--config",
+        "production"
+      ],
+      "env": { "DOPPLER_TOKEN": "dp.pt.xxx" }
+    }
+  }
+}
+```
+
+## Implicit Scope Detection
+
+The server automatically detects scope based on your token's access:
+
+| Token Access                   | Auto-Detected Scope                          |
+| ------------------------------ | -------------------------------------------- |
+| Single project                 | `--project` set automatically                |
+| Single project + single config | `--project` and `--config` set automatically |
+| Multiple projects              | No auto-detection (use CLI flags)            |
+
+This means **scoped service tokens work out of the box** without any CLI flags:
+
+```json
+{
+  "mcpServers": {
+    "doppler": {
+      "command": "npx",
+      "args": ["-y", "@dopplerhq/mcp-server", "--read-only"],
+      "env": {
+        "DOPPLER_TOKEN": "dp.st.xxx"
+      }
+    }
+  }
+}
+```
+
+CLI flags always take precedence over auto-detected values.
+
+## Security Best Practices
+
+**Use scoped service tokens, not CLI flags, for access control.** The `--project` and `--config` flags provide a convenient UX layer but are not a substitute for proper token scoping. Always create service tokens with the minimum required permissions:
+
+1. **Scope tokens to specific projects** in the Doppler dashboard
+2. **Use read-only tokens** when write access isn't needed
+3. **Combine read-only tokens with `--read-only`** for defense in depth:
+
+```json
+{
+  "mcpServers": {
+    "doppler": {
+      "command": "npx",
+      "args": ["-y", "@dopplerhq/mcp-server", "--read-only"],
+      "env": {
+        "DOPPLER_TOKEN": "dp.st.readonly_token"
+      }
+    }
+  }
+}
+```
+
+Note: The server cannot determine read/write permissions from the token, so if you're using a read-only token, add `--read-only` to only expose read tools. This prevents write tools from appearing in Claude's tool list and avoids failed API calls.
+
+## Available Tools
+
+The server auto-generates tools from the [Doppler OpenAPI spec](https://docs.doppler.com/reference/api). The tools available depend on your flags:
+
+### No flags (full access)
+
+All Doppler API tools including:
+
+- **Workplace**: `workplace_get`, `workplace_update`
+- **Users & Groups**: `users_list`, `groups_list`, `service_accounts_list`
+- **Projects**: `projects_list`, `projects_create`, `projects_get`, `projects_delete`
+- **Environments**: `environments_list`, `environments_create`, `environments_get`
+- **Configs**: `configs_list`, `configs_create`, `configs_get`, `configs_update`, `configs_lock`
+- **Secrets**: `secrets_list`, `secrets_get`, `secrets_update`, `secrets_download`
+- **Integrations**: `integrations_list`, `syncs_list`, `webhooks_list`
+
+### With `--read-only`
+
+Read-only tools only (GET operations). Write operations like `_create`, `_update`, `_delete` are not exposed.
+
+### With `--project`
+
+Org-level tools are filtered out (`workplace_*`, `activity_logs_*`). The `project` parameter is auto-injected into tool calls that accept it.
+
+### With `--config`
+
+Only config and secret management tools:
+
+- `configs_get`, `configs_update`, `configs_lock`, `configs_unlock`
+- `secrets_list`, `secrets_get`, `secrets_update`, `secrets_download`
+- `config_logs_list`, `config_logs_rollback`
+
+Both `project` and `config` parameters are auto-injected.
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+
+# Run tests
+pnpm test
+
+# Build
+pnpm run build
+
+# Run locally
+DOPPLER_TOKEN=dp.xxx pnpm start
+```

--- a/bin/doppler-mcp
+++ b/bin/doppler-mcp
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import path from "path";
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
+import fs from "fs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const entryPoint = path.join(__dirname, "..", "dist", "index.js");
+
+// Check if the compiled version exists
+if (!fs.existsSync(entryPoint)) {
+  console.error("Error: Compiled JavaScript not found.");
+  console.error(
+    'Please run "npm run build" first, or use "npm run dev" for development.',
+  );
+  process.exit(1);
+}
+
+// Forward all arguments and spawn the main process
+const child = spawn("node", [entryPoint, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+// Forward exit codes
+child.on("exit", (code) => {
+  process.exit(code);
+});
+
+// Handle process signals
+process.on("SIGINT", () => {
+  if (child.kill) {
+    child.kill("SIGINT");
+  }
+});
+
+process.on("SIGTERM", () => {
+  if (child.kill) {
+    child.kill("SIGTERM");
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,14 +1,53 @@
 {
   "name": "@dopplerhq/mcp-server",
   "version": "0.0.0",
+  "private": true,
+  "description": "MCP server for Doppler API with auto-generated tools from OpenAPI specification",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "doppler-mcp": "./bin/doppler-mcp"
+  },
+  "scripts": {
+    "fetch-openapi": "curl -s https://docs.doppler.com/openapi/core.json -o doppler-openapi.json",
+    "prebuild": "npm run fetch-openapi",
+    "build": "tsc && cp doppler-openapi.json dist/",
+    "dev": "tsx --esm src/index.ts",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
+  },
   "files": [
-    "package.json"
+    "dist/",
+    "bin/",
+    "README.md"
   ],
-  "scripts": {},
+  "keywords": [
+    "mcp",
+    "doppler",
+    "secrets",
+    "api",
+    "openapi",
+    "model-context-protocol"
+  ],
+  "license": "MIT",
   "publishConfig": {
     "provenance": true
   },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.5.0",
+    "fastmcp": "^3.10.0",
+    "zod": "^3.22.0"
+  },
   "devDependencies": {
-    "prettier": "^3.6.2"
+    "@types/node": "^20.0.0",
+    "prettier": "^3.6.2",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2342 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^0.5.0
+        version: 0.5.0
+      fastmcp:
+        specifier: ^3.10.0
+        version: 3.26.8(hono@4.11.3)
+      zod:
+        specifier: ^3.22.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.28
+      prettier:
+        specifier: ^3.6.2
+        version: 3.7.4
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.28)
+
+packages:
+
+  '@borewit/text-codec@0.2.1':
+    resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.2':
+    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.2':
+    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.2':
+    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.2':
+    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.2':
+    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.2':
+    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.2':
+    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.2':
+    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.2':
+    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.2':
+    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.2':
+    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.2':
+    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.2':
+    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.2':
+    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.2':
+    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.2':
+    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.2':
+    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.2':
+    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.2':
+    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.2':
+    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.2':
+    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.2':
+    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hono/node-server@1.19.8':
+    resolution: {integrity: sha512-0/g2lIOPzX8f3vzW1ggQgvG5mjtFBDBHFAzI5SFAi2DzSqS9luJwqg9T6O/gKYLi+inS7eNxBeIFkkghIPvrMA==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@0.5.0':
+    resolution: {integrity: sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ==}
+
+  '@modelcontextprotocol/sdk@1.25.2':
+    resolution: {integrity: sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.55.1':
+    resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.55.1':
+    resolution: {integrity: sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.55.1':
+    resolution: {integrity: sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.55.1':
+    resolution: {integrity: sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.55.1':
+    resolution: {integrity: sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.55.1':
+    resolution: {integrity: sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
+    resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.55.1':
+    resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.55.1':
+    resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.55.1':
+    resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.55.1':
+    resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.55.1':
+    resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.55.1':
+    resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.55.1':
+    resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.55.1':
+    resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.55.1':
+    resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.55.1':
+    resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.55.1':
+    resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.55.1':
+    resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.55.1':
+    resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.55.1':
+    resolution: {integrity: sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.55.1':
+    resolution: {integrity: sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.55.1':
+    resolution: {integrity: sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.55.1':
+    resolution: {integrity: sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.55.1':
+    resolution: {integrity: sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@20.19.28':
+    resolution: {integrity: sha512-VyKBr25BuFDzBFCK5sUM6ZXiWfqgCTwTAOK8qzGV/m9FCirXYDlmczJ+d5dXBAQALGCdRRdbteKYfJ84NGEusw==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.27.2:
+    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastmcp@3.26.8:
+    resolution: {integrity: sha512-DQgvEdSoQpISqPDgLZe5K2RU8ICCz3/5QcEhHmz4KiNcNSdFOo7o817mGwWxPffOLe36vypCulq22cvEwqBi/A==}
+    hasBin: true
+    peerDependencies:
+      jose: ^5.0.0
+    peerDependenciesMeta:
+      jose:
+        optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
+
+  file-type@21.3.0:
+    resolution: {integrity: sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==}
+    engines: {node: '>=20'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fuse.js@7.1.0:
+    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
+    engines: {node: '>=10'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.4.0:
+    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+    engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
+  get-tsconfig@4.13.0:
+    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.11.3:
+    resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mcp-proxy@5.12.5:
+    resolution: {integrity: sha512-Vawdc8vi36fXxKCaDpluRvbGcmrUXJdvXcDhkh30HYsws8XqX2rWPBflZpavzeS+6SwijRFV7g+9ypQRJZlrEQ==}
+    hasBin: true
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prettier@3.7.4:
+    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.55.1:
+    resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strict-event-emitter-types@2.0.0:
+    resolution: {integrity: sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  strip-ansi@7.1.2:
+    resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
+    engines: {node: '>=12'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
+  strtok3@10.3.4:
+    resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
+    engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.18.2:
+    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
+    engines: {node: '>=20.18.1'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  uri-templates@0.2.0:
+    resolution: {integrity: sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xsschema@0.4.0-beta.5:
+    resolution: {integrity: sha512-73pYwf1hMy++7SnOkghJdgdPaGi+Y5I0SaO6rIlxb1ouV6tEyDbEcXP82kyr32KQVTlUbFj6qewi9eUVEiXm+g==}
+    peerDependencies:
+      '@valibot/to-json-schema': ^1.0.0
+      arktype: ^2.1.20
+      effect: ^3.16.0
+      sury: ^10.0.0
+      zod: ^3.25.0 || ^4.0.0
+      zod-to-json-schema: ^3.24.5
+    peerDependenciesMeta:
+      '@valibot/to-json-schema':
+        optional: true
+      arktype:
+        optional: true
+      effect:
+        optional: true
+      sury:
+        optional: true
+      zod:
+        optional: true
+      zod-to-json-schema:
+        optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.3.5:
+    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
+
+snapshots:
+
+  '@borewit/text-codec@0.2.1': {}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@hono/node-server@1.19.8(hono@4.11.3)':
+    dependencies:
+      hono: 4.11.3
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@0.5.0':
+    dependencies:
+      content-type: 1.0.5
+      raw-body: 3.0.2
+      zod: 3.25.76
+
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.3.5)':
+    dependencies:
+      '@hono/node-server': 1.19.8(hono@4.11.3)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.5
+      zod-to-json-schema: 3.25.1(zod@4.3.5)
+    transitivePeerDependencies:
+      - hono
+      - supports-color
+
+  '@rollup/rollup-android-arm-eabi@4.55.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.55.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.55.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.55.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.55.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.55.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.55.1':
+    optional: true
+
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@20.19.28':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.28))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.28)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
+  assertion-error@2.0.1: {}
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.14.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+      wrap-ansi: 9.0.2
+
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  depd@2.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  emoji-regex@10.6.0: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.27.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.2
+      '@esbuild/android-arm': 0.27.2
+      '@esbuild/android-arm64': 0.27.2
+      '@esbuild/android-x64': 0.27.2
+      '@esbuild/darwin-arm64': 0.27.2
+      '@esbuild/darwin-x64': 0.27.2
+      '@esbuild/freebsd-arm64': 0.27.2
+      '@esbuild/freebsd-x64': 0.27.2
+      '@esbuild/linux-arm': 0.27.2
+      '@esbuild/linux-arm64': 0.27.2
+      '@esbuild/linux-ia32': 0.27.2
+      '@esbuild/linux-loong64': 0.27.2
+      '@esbuild/linux-mips64el': 0.27.2
+      '@esbuild/linux-ppc64': 0.27.2
+      '@esbuild/linux-riscv64': 0.27.2
+      '@esbuild/linux-s390x': 0.27.2
+      '@esbuild/linux-x64': 0.27.2
+      '@esbuild/netbsd-arm64': 0.27.2
+      '@esbuild/netbsd-x64': 0.27.2
+      '@esbuild/openbsd-arm64': 0.27.2
+      '@esbuild/openbsd-x64': 0.27.2
+      '@esbuild/openharmony-arm64': 0.27.2
+      '@esbuild/sunos-x64': 0.27.2
+      '@esbuild/win32-arm64': 0.27.2
+      '@esbuild/win32-ia32': 0.27.2
+      '@esbuild/win32-x64': 0.27.2
+
+  escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
+
+  express-rate-limit@7.5.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  fastmcp@3.26.8(hono@4.11.3):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.3.5)
+      '@standard-schema/spec': 1.1.0
+      execa: 9.6.1
+      file-type: 21.3.0
+      fuse.js: 7.1.0
+      mcp-proxy: 5.12.5
+      strict-event-emitter-types: 2.0.0
+      undici: 7.18.2
+      uri-templates: 0.2.0
+      xsschema: 0.4.0-beta.5(zod-to-json-schema@3.25.1(zod@4.3.5))(zod@4.3.5)
+      yargs: 18.0.0
+      zod: 4.3.5
+      zod-to-json-schema: 3.25.1(zod@4.3.5)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@valibot/to-json-schema'
+      - arktype
+      - effect
+      - hono
+      - supports-color
+      - sury
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
+
+  file-type@21.3.0:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.4
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  fuse.js@7.1.0: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.4.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
+  get-tsconfig@4.13.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.11.3: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  human-signals@8.0.1: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-plain-obj@4.1.0: {}
+
+  is-promise@4.0.0: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
+
+  isexe@2.0.0: {}
+
+  jose@6.1.3: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  mcp-proxy@5.12.5: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  negotiator@1.0.0: {}
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parse-ms@4.0.0: {}
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
+
+  path-to-regexp@8.3.0: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  pkce-challenge@5.0.1: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prettier@3.7.4: {}
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.14.1:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  require-from-string@2.0.2: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.55.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.55.1
+      '@rollup/rollup-android-arm64': 4.55.1
+      '@rollup/rollup-darwin-arm64': 4.55.1
+      '@rollup/rollup-darwin-x64': 4.55.1
+      '@rollup/rollup-freebsd-arm64': 4.55.1
+      '@rollup/rollup-freebsd-x64': 4.55.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.55.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.55.1
+      '@rollup/rollup-linux-arm64-gnu': 4.55.1
+      '@rollup/rollup-linux-arm64-musl': 4.55.1
+      '@rollup/rollup-linux-loong64-gnu': 4.55.1
+      '@rollup/rollup-linux-loong64-musl': 4.55.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.55.1
+      '@rollup/rollup-linux-ppc64-musl': 4.55.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.55.1
+      '@rollup/rollup-linux-riscv64-musl': 4.55.1
+      '@rollup/rollup-linux-s390x-gnu': 4.55.1
+      '@rollup/rollup-linux-x64-gnu': 4.55.1
+      '@rollup/rollup-linux-x64-musl': 4.55.1
+      '@rollup/rollup-openbsd-x64': 4.55.1
+      '@rollup/rollup-openharmony-arm64': 4.55.1
+      '@rollup/rollup-win32-arm64-msvc': 4.55.1
+      '@rollup/rollup-win32-ia32-msvc': 4.55.1
+      '@rollup/rollup-win32-x64-gnu': 4.55.1
+      '@rollup/rollup-win32-x64-msvc': 4.55.1
+      fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strict-event-emitter-types@2.0.0: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.4.0
+      strip-ansi: 7.1.2
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strip-final-newline@4.0.0: {}
+
+  strtok3@10.3.4:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  toidentifier@1.0.1: {}
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.1
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.2
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typescript@5.9.3: {}
+
+  uint8array-extras@1.5.0: {}
+
+  undici-types@6.21.0: {}
+
+  undici@7.18.2: {}
+
+  unicorn-magic@0.3.0: {}
+
+  unpipe@1.0.0: {}
+
+  uri-templates@0.2.0: {}
+
+  vary@1.1.2: {}
+
+  vite-node@2.1.9(@types/node@20.19.28):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.28)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.28):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.55.1
+    optionalDependencies:
+      '@types/node': 20.19.28
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@20.19.28):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.28))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.28)
+      vite-node: 2.1.9(@types/node@20.19.28)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.28
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+
+  wrappy@1.0.2: {}
+
+  xsschema@0.4.0-beta.5(zod-to-json-schema@3.25.1(zod@4.3.5))(zod@4.3.5):
+    optionalDependencies:
+      zod: 4.3.5
+      zod-to-json-schema: 3.25.1(zod@4.3.5)
+
+  y18n@5.0.8: {}
+
+  yargs-parser@22.0.0: {}
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
+
+  yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.1(zod@4.3.5):
+    dependencies:
+      zod: 4.3.5
+
+  zod@3.25.76: {}
+
+  zod@4.3.5: {}

--- a/src/access-warnings.ts
+++ b/src/access-warnings.ts
@@ -1,0 +1,184 @@
+import { z } from "zod";
+import { type TokenType } from "./auth.js";
+
+export interface AccessContext {
+  tokenType: TokenType;
+  readOnly: boolean;
+  project?: string;
+  config?: string;
+}
+
+export type AccessLevel = "info" | "warning" | "critical";
+
+export interface AccessMessage {
+  level: AccessLevel;
+  emoji: "ℹ️" | "⚠️" | "🚨";
+  message: string;
+}
+
+/**
+ * Check if config name indicates production (prod, prd, production, live).
+ * Matches exact names and suffix patterns (*_prod, *-prod, etc).
+ */
+export function isProductionConfig(config: string): boolean {
+  if (!config?.trim()) {
+    return false;
+  }
+
+  const prodPatterns = [
+    /^prod$/i,
+    /^prd$/i,
+    /^production$/i,
+    /^live$/i,
+    /_prod$/i,
+    /_prd$/i,
+    /_production$/i,
+    /-prod$/i,
+    /-prd$/i,
+    /-production$/i,
+  ];
+
+  return prodPatterns.some((pattern) => pattern.test(config));
+}
+
+const TOKEN_TYPE_LABELS: Record<TokenType, string> = {
+  service_token: "service token (project-scoped)",
+  service_account: "service account",
+  personal: "personal token",
+  cli: "CLI token",
+  scim: "SCIM token",
+  unknown: "unknown",
+};
+
+export function getAccessMessages(ctx: AccessContext): AccessMessage[] {
+  const messages: AccessMessage[] = [];
+
+  // Info messages - always included to show current scope
+  messages.push({
+    level: "info",
+    emoji: "ℹ️",
+    message: `Token type: ${TOKEN_TYPE_LABELS[ctx.tokenType]}`,
+  });
+
+  if (ctx.project) {
+    messages.push({
+      level: "info",
+      emoji: "ℹ️",
+      message: `Project: ${ctx.project}`,
+    });
+  }
+
+  if (ctx.config) {
+    messages.push({
+      level: "info",
+      emoji: "ℹ️",
+      message: `Config: ${ctx.config}`,
+    });
+  }
+
+  if (ctx.readOnly) {
+    messages.push({
+      level: "info",
+      emoji: "ℹ️",
+      message: "Mode: read-only",
+    });
+  }
+
+  // Critical messages - serious concerns
+  if (ctx.tokenType === "unknown") {
+    messages.push({
+      level: "critical",
+      emoji: "🚨",
+      message: "UNKNOWN TOKEN TYPE - exercise extreme caution",
+    });
+  } else if (ctx.tokenType === "scim") {
+    messages.push({
+      level: "critical",
+      emoji: "🚨",
+      message:
+        "SCIM TOKEN - intended for user provisioning, not secrets access",
+    });
+  }
+
+  if (ctx.config && isProductionConfig(ctx.config)) {
+    messages.push({
+      level: "critical",
+      emoji: "🚨",
+      message: `PRODUCTION CONFIG: ${ctx.config}`,
+    });
+  }
+
+  // Warning messages - elevated concerns
+  if (!ctx.readOnly) {
+    messages.push({
+      level: "warning",
+      emoji: "⚠️",
+      message: "Write tools exposed - use caution when modifying secrets",
+    });
+  }
+
+  if (!ctx.project) {
+    messages.push({
+      level: "warning",
+      emoji: "⚠️",
+      message: "No project filter applied",
+    });
+  }
+
+  return messages;
+}
+
+/**
+ * Create confirm_access tool requiring user acknowledgment before using Doppler tools.
+ * Returns null if only info-level messages (safe mode).
+ */
+export function createConfirmAccessTool(ctx: AccessContext) {
+  const messages = getAccessMessages(ctx);
+  const infoMessages = messages.filter((m) => m.level === "info");
+  const actionableMessages = messages.filter(
+    (m) => m.level === "warning" || m.level === "critical",
+  );
+
+  if (actionableMessages.length === 0) {
+    return null;
+  }
+
+  const description =
+    "🛑 REQUIRED FIRST STEP: Call before any other Doppler tool. " +
+    "Returns access level warnings that must be shown to the user for confirmation.";
+
+  const scopeLines = infoMessages
+    .map((m) => `  ${m.emoji} ${m.message}`)
+    .join("\n");
+  const warningLines = actionableMessages
+    .map((w) => `  ${w.emoji} ${w.message}`)
+    .join("\n");
+
+  return {
+    name: "confirm_access",
+    description,
+    parameters: z.object({}),
+    execute: async () => {
+      return `<security_confirmation required="true">
+<instructions>
+Before proceeding with any Doppler operations, you must obtain explicit user consent.
+Display the access summary below to the user VERBATIM - do not summarize or rephrase.
+The emojis and formatting are intentional for scannability.
+</instructions>
+
+<display_to_user>
+Current access scope:
+${scopeLines}
+
+Warnings requiring confirmation:
+${warningLines}
+</display_to_user>
+
+<then>
+Ask the user: "Do you want me to proceed?"
+Wait for explicit confirmation (e.g., "yes", "proceed", "go ahead") before calling any other Doppler tools.
+</then>
+</security_confirmation>`;
+    },
+  };
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,140 @@
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+export type TokenType =
+  | "service_token" // dp.st.* - Project/config scoped
+  | "service_account" // dp.sa.* - Workspace automation
+  | "personal" // dp.pt.* - User personal token
+  | "cli" // dp.ct.* - CLI token
+  | "scim" // dp.scim.* - SCIM provisioning
+  | "unknown";
+
+interface DopplerConfig {
+  token: string;
+  baseUrl: string;
+}
+
+/**
+ * Detect token type from Doppler token prefix.
+ * Formats: dp.st.* (service account), dp.pt.* (personal), dp.ct.* (CLI)
+ */
+export function detectTokenType(token: string): TokenType {
+  if (!token?.trim() || !token.startsWith("dp.")) {
+    return "unknown";
+  }
+
+  const parts = token.split(".");
+  if (parts.length < 3 || !parts[2]) {
+    return "unknown";
+  }
+
+  switch (parts[1]) {
+    case "st":
+      return "service_token"; // Project/config scoped service token
+    case "sa":
+      return "service_account"; // Workspace-level service account
+    case "pt":
+      return "personal";
+    case "ct":
+      return "cli";
+    case "scim":
+      return "scim";
+    default:
+      return "unknown";
+  }
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Read version from package.json at startup
+function getPackageVersion(): string {
+  try {
+    const packagePath = path.join(__dirname, "..", "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf-8"));
+    return packageJson.version || "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+const VERSION = getPackageVersion();
+
+export class AuthManager {
+  private config: DopplerConfig;
+
+  constructor() {
+    this.config = this.loadConfig();
+  }
+
+  private loadConfig(): DopplerConfig {
+    const token = process.env.DOPPLER_TOKEN;
+
+    if (!token) {
+      throw new Error(
+        "DOPPLER_TOKEN environment variable is required. " +
+          "Please set it to your Doppler API token.",
+      );
+    }
+
+    // Validate token format (Doppler tokens typically start with 'dp.')
+    if (!token.startsWith("dp.")) {
+      console.warn(
+        "Warning: DOPPLER_TOKEN does not appear to be a valid Doppler token format. " +
+          'Valid tokens typically start with "dp."',
+      );
+    }
+
+    return {
+      token,
+      baseUrl: process.env.DOPPLER_BASE_URL || "https://api.doppler.com",
+    };
+  }
+
+  public getAuthHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.config.token}`,
+      "Content-Type": "application/json",
+      "User-Agent": `doppler-mcp-server/${VERSION}`,
+    };
+  }
+
+  public getBaseUrl(): string {
+    return this.config.baseUrl;
+  }
+
+  public static validateEnvironment(): { valid: boolean; errors: string[] } {
+    const errors: string[] = [];
+
+    if (!process.env.DOPPLER_TOKEN) {
+      errors.push("DOPPLER_TOKEN environment variable is required");
+    } else if (!process.env.DOPPLER_TOKEN.startsWith("dp.")) {
+      errors.push(
+        "DOPPLER_TOKEN does not appear to be a valid Doppler token format",
+      );
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+    };
+  }
+
+  public static getSetupInstructions(): string {
+    return `
+To use this MCP server, you need to set the DOPPLER_TOKEN environment variable:
+
+1. Get your Doppler API token from: https://dashboard.doppler.com/access-tokens
+2. Set the environment variable:
+   export DOPPLER_TOKEN=dp.your-token-here
+3. Run the MCP server:
+   npx @dopplerhq/mcp-server
+
+Example:
+  DOPPLER_TOKEN=dp.your-token-here npx @dopplerhq/mcp-server
+
+For more information, visit: https://docs.doppler.com/reference/api
+    `;
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,139 @@
+import { AuthManager } from "./auth.js";
+import { APIError } from "./errors.js";
+
+export { APIError };
+
+export interface RequestOptions {
+  method: string;
+  endpoint: string;
+  queryParams?: Record<string, string>;
+  body?: any;
+}
+
+export class DopplerClient {
+  private authManager: AuthManager;
+  private baseUrl: string;
+
+  constructor() {
+    this.authManager = new AuthManager();
+    this.baseUrl = this.authManager.getBaseUrl();
+  }
+
+  public async makeRequest(options: RequestOptions): Promise<any> {
+    const { method, endpoint, queryParams, body } = options;
+
+    let url = `${this.baseUrl}${endpoint}`;
+    if (queryParams && Object.keys(queryParams).length > 0) {
+      const searchParams = new URLSearchParams();
+      for (const [key, value] of Object.entries(queryParams)) {
+        if (value !== undefined && value !== null) {
+          searchParams.append(key, String(value));
+        }
+      }
+      url += `?${searchParams.toString()}`;
+    }
+
+    const requestOptions: RequestInit = {
+      method,
+      headers: this.authManager.getAuthHeaders(),
+    };
+
+    if (body && ["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+      requestOptions.body = JSON.stringify(body);
+    }
+
+    try {
+      const response = await fetch(url, requestOptions);
+
+      if (!response.ok) {
+        throw await this.handleErrorResponse(response);
+      }
+
+      const contentType = response.headers.get("content-type");
+      if (!contentType || !contentType.includes("application/json")) {
+        const text = await response.text();
+        return text || { success: true };
+      }
+
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      if (error instanceof Error && "statusCode" in error) {
+        throw error;
+      }
+
+      throw new APIError(
+        "Network or request error",
+        error instanceof Error ? error.message : "Unknown error occurred",
+        0,
+      );
+    }
+  }
+
+  private async handleErrorResponse(response: Response): Promise<APIError> {
+    let errorMessage = `HTTP ${response.status} ${response.statusText}`;
+    let errorDetails = errorMessage;
+
+    try {
+      const contentType = response.headers.get("content-type");
+      if (contentType && contentType.includes("application/json")) {
+        const errorData = await response.json();
+
+        if (errorData.messages && Array.isArray(errorData.messages)) {
+          errorMessage = errorData.messages.join(", ");
+        } else if (errorData.message) {
+          errorMessage = errorData.message;
+        } else if (errorData.error) {
+          errorMessage = errorData.error;
+        }
+
+        errorDetails = JSON.stringify(errorData, null, 2);
+      } else {
+        errorDetails = await response.text();
+      }
+    } catch {
+      errorDetails = `Failed to parse error response: ${response.statusText}`;
+    }
+
+    return new APIError(errorDetails, errorMessage, response.status);
+  }
+
+  public async testConnection(): Promise<{ success: boolean; error?: string }> {
+    try {
+      await this.makeRequest({
+        method: "GET",
+        endpoint: "/v3/workplace",
+      });
+      return { success: true };
+    } catch (error) {
+      const apiError = error as APIError;
+      return {
+        success: false,
+        error: `Connection test failed: ${apiError.message} (Status: ${apiError.statusCode})`,
+      };
+    }
+  }
+
+  public getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  public async listProjects(): Promise<Array<{ slug: string }>> {
+    const response = await this.makeRequest({
+      method: "GET",
+      endpoint: "/v3/projects",
+    });
+    return response.projects ?? [];
+  }
+
+  public async listConfigs(
+    project: string,
+  ): Promise<Array<{ name: string; slug: string }>> {
+    const response = await this.makeRequest({
+      method: "GET",
+      endpoint: "/v3/configs",
+      queryParams: { project },
+    });
+    return response.configs ?? [];
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,18 @@
+export class APIError extends Error {
+  public readonly error: string;
+  public readonly statusCode: number;
+
+  constructor(error: string, message: string, statusCode: number) {
+    super(message);
+    this.name = "APIError";
+    this.error = error;
+    this.statusCode = statusCode;
+  }
+}
+
+export class ScopeViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ScopeViolationError";
+  }
+}

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,0 +1,137 @@
+import { DopplerTool, Parameter } from "./types.js";
+import { DopplerClient, APIError } from "./client.js";
+import { type ScopeOptions } from "./scope.js";
+import { ScopeViolationError } from "./errors.js";
+
+export class ToolGenerator {
+  private client: DopplerClient;
+  private scope?: ScopeOptions;
+
+  constructor(client: DopplerClient, scope?: ScopeOptions) {
+    this.client = client;
+    this.scope = scope;
+  }
+
+  public generateTools(dopplerTools: DopplerTool[]): any[] {
+    return dopplerTools.map((dopplerTool) => this.createMCPTool(dopplerTool));
+  }
+
+  private createMCPTool(dopplerTool: DopplerTool): any {
+    return {
+      name: dopplerTool.name,
+      description: dopplerTool.description,
+      parameters: dopplerTool.inputSchema,
+      execute: async (input: any) => {
+        try {
+          const result = await this.executeTool(dopplerTool, input);
+          return this.formatResponse(result);
+        } catch (error) {
+          if (error instanceof ScopeViolationError) {
+            throw error;
+          }
+          const apiError = error as APIError;
+          throw new Error(this.formatError(apiError));
+        }
+      },
+    };
+  }
+
+  private async executeTool(tool: DopplerTool, input: any): Promise<any> {
+    if (
+      this.scope?.project &&
+      input.project &&
+      input.project !== this.scope.project
+    ) {
+      const message =
+        this.scope.projectSource === "token"
+          ? `Project scope violation: Your token only has access to project "${this.scope.project}", ` +
+            `but the request targets project "${input.project}".`
+          : `Project scope violation: This server is configured for project "${this.scope.project}" ` +
+            `but the request targets project "${input.project}". ` +
+            `Remove the project parameter to use the configured project, or reconfigure the server.`;
+      throw new ScopeViolationError(message);
+    }
+
+    if (
+      this.scope?.config &&
+      input.config &&
+      input.config !== this.scope.config
+    ) {
+      const message =
+        this.scope.configSource === "token"
+          ? `Config scope violation: Your token only has access to config "${this.scope.config}", ` +
+            `but the request targets config "${input.config}".`
+          : `Config scope violation: This server is configured for config "${this.scope.config}" ` +
+            `but the request targets config "${input.config}". ` +
+            `Remove the config parameter to use the configured config, or reconfigure the server.`;
+      throw new ScopeViolationError(message);
+    }
+
+    if (this.scope?.config && tool.parameters) {
+      const configParam = tool.parameters.find((p) => p.name === "config");
+      if (configParam && !input.config) {
+        input.config = this.scope.config;
+      }
+    }
+
+    if (this.scope?.project && tool.parameters) {
+      const projectParam = tool.parameters.find((p) => p.name === "project");
+      if (projectParam && !input.project) {
+        input.project = this.scope.project;
+      }
+    }
+
+    const pathParams: Record<string, string> = {};
+    const queryParams: Record<string, string> = {};
+    const bodyData: Record<string, any> = {};
+
+    if (tool.parameters) {
+      for (const param of tool.parameters) {
+        if (input[param.name] !== undefined) {
+          if (param.in === "path") {
+            pathParams[param.name] = input[param.name];
+          } else if (param.in === "query") {
+            queryParams[param.name] = input[param.name];
+          }
+        }
+      }
+    }
+
+    if (tool.requestBody) {
+      const contentType = Object.keys(tool.requestBody.content)[0];
+      if (contentType === "application/json") {
+        // Include all input properties that aren't path/query params
+        // This allows arbitrary properties (like custom secret names) to pass through
+        for (const [key, value] of Object.entries(input)) {
+          const isPathOrQueryParam = key in pathParams || key in queryParams;
+          if (!isPathOrQueryParam && value !== undefined) {
+            bodyData[key] = value;
+          }
+        }
+      }
+    }
+
+    let endpoint = tool.endpoint;
+    for (const [key, value] of Object.entries(pathParams)) {
+      endpoint = endpoint.replace(`{${key}}`, encodeURIComponent(value));
+    }
+
+    return await this.client.makeRequest({
+      method: tool.method,
+      endpoint,
+      queryParams,
+      body: Object.keys(bodyData).length > 0 ? bodyData : undefined,
+    });
+  }
+
+  private formatResponse(response: any): string {
+    if (typeof response === "object") {
+      return JSON.stringify(response, null, 2);
+    }
+    return String(response);
+  }
+
+  private formatError(error: APIError): string {
+    return `Error ${error.statusCode}: ${error.message}\n\nDetails: ${error.error}`;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+
+import { FastMCP } from "fastmcp";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+import { OpenAPIParser } from "./parser.js";
+import { ToolGenerator } from "./generator.js";
+import { DopplerClient } from "./client.js";
+import { AuthManager, detectTokenType } from "./auth.js";
+import { OpenAPISpec } from "./types.js";
+import { detectImplicitScope, mergeScope, validateScope } from "./scope.js";
+import {
+  getAccessMessages,
+  createConfirmAccessTool,
+  type AccessContext,
+} from "./access-warnings.js";
+
+interface CLIOptions {
+  readOnly?: boolean;
+  project?: string;
+  config?: string;
+  help?: boolean;
+  verbose?: boolean;
+}
+
+const ORG_LEVEL_ENDPOINT_PREFIXES = ["/v3/workplace", "/v3/logs"];
+
+let verboseMode = false;
+
+function log(message: string) {
+  if (verboseMode) {
+    console.error(message);
+  }
+}
+
+function warn(message: string) {
+  console.error(message);
+}
+
+function emitStartupMessages(ctx: AccessContext) {
+  for (const m of getAccessMessages(ctx)) {
+    if (m.level === "info") {
+      log(`${m.emoji} ${m.message}`);
+    } else {
+      warn(`${m.emoji} ${m.message}`);
+    }
+  }
+}
+
+function parseCLIArgs(): CLIOptions {
+  const args = process.argv.slice(2);
+  const options: CLIOptions = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    switch (arg) {
+      case "--read-only":
+        options.readOnly = true;
+        break;
+      case "--project":
+        options.project = args[++i];
+        break;
+      case "--config":
+        options.config = args[++i];
+        break;
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      case "--verbose":
+      case "-v":
+        options.verbose = true;
+        break;
+    }
+  }
+
+  return options;
+}
+
+function showHelp() {
+  console.log(`
+Doppler MCP Server
+
+Usage: npx @dopplerhq/mcp-server [options]
+
+Options:
+  --read-only        Enable read-only mode (only GET operations)
+  --project <name>   Override auto-detected project
+  --config <name>    Override auto-detected config
+  --verbose, -v      Enable verbose logging to stderr
+  --help, -h         Show this help message
+
+Environment Variables:
+  DOPPLER_TOKEN        Your Doppler API token (required)
+  DOPPLER_BASE_URL     Base URL for Doppler API (optional)
+
+Scope Detection:
+  The server auto-detects scope from your token's access:
+  - Single project access → project set automatically
+  - Single config access  → config set automatically
+  CLI flags override auto-detected values.
+
+Examples:
+  # Basic usage (scope auto-detected from token)
+  DOPPLER_TOKEN=dp.st.xxx npx @dopplerhq/mcp-server
+
+  # Read-only mode
+  DOPPLER_TOKEN=dp.xxx npx @dopplerhq/mcp-server --read-only
+
+  # Override auto-detected project
+  DOPPLER_TOKEN=dp.xxx npx @dopplerhq/mcp-server --project my-app
+`);
+}
+
+async function createDopplerMCPServer(options: CLIOptions = {}) {
+  verboseMode = options.verbose ?? false;
+
+  try {
+    const validation = AuthManager.validateEnvironment();
+    if (!validation.valid) {
+      console.error("Environment validation failed:");
+      for (const error of validation.errors) {
+        console.error(`  - ${error}`);
+      }
+      console.error("\n" + AuthManager.getSetupInstructions());
+      process.exit(1);
+    }
+
+    const specPath = path.join(__dirname, "..", "doppler-openapi.json");
+    let openApiSpec: OpenAPISpec;
+
+    try {
+      const specContent = fs.readFileSync(specPath, "utf-8");
+      openApiSpec = JSON.parse(specContent);
+    } catch (error) {
+      console.error(
+        `Failed to load OpenAPI specification from ${specPath}:`,
+        error,
+      );
+      process.exit(1);
+    }
+
+    const parser = new OpenAPIParser(openApiSpec);
+    const client = new DopplerClient();
+
+    log("Testing Doppler API connection...");
+    const connectionTest = await client.testConnection();
+    if (!connectionTest.success) {
+      console.error("Failed to connect to Doppler API:", connectionTest.error);
+      console.error("\nPlease check your DOPPLER_TOKEN and try again.");
+      process.exit(1);
+    }
+    log("✓ Successfully connected to Doppler API");
+
+    // Detect token type early - needed to decide if auto-scope is safe
+    const token = process.env.DOPPLER_TOKEN ?? "";
+    const tokenType = detectTokenType(token);
+
+    // Only auto-detect scope for service tokens (dp.st.*) which are genuinely
+    // scoped by Doppler. For other token types (service accounts, personal, etc.),
+    // seeing one project just means "workspace currently has one project" -
+    // creating another would change the scope unexpectedly.
+    const detectedScope =
+      tokenType === "service_token"
+        ? await detectImplicitScope(client)
+        : { project: undefined, config: undefined };
+
+    const cliScope = { project: options.project, config: options.config };
+    validateScope(detectedScope, cliScope);
+
+    const effectiveScope = mergeScope(detectedScope, cliScope);
+
+    if (detectedScope.project || detectedScope.config) {
+      const parts = [];
+      if (detectedScope.project)
+        parts.push(`project: ${detectedScope.project}`);
+      if (detectedScope.config) parts.push(`config: ${detectedScope.config}`);
+      log(`✓ Auto-detected scope: ${parts.join(", ")}`);
+    }
+
+    const scopeOptions = {
+      project: effectiveScope.project,
+      projectSource: options.project
+        ? "cli"
+        : detectedScope.project
+          ? "token"
+          : undefined,
+      config: effectiveScope.config,
+      configSource: options.config
+        ? "cli"
+        : detectedScope.config
+          ? "token"
+          : undefined,
+    } as const;
+
+    const generator = new ToolGenerator(client, scopeOptions);
+
+    log("Parsing OpenAPI specification...");
+    let dopplerTools = parser.parseToTools();
+
+    if (options.readOnly) {
+      dopplerTools = dopplerTools.filter((tool) => tool.method === "GET");
+      log(`✓ Filtered to ${dopplerTools.length} read-only endpoints`);
+    } else {
+      log(`✓ Parsed ${dopplerTools.length} API endpoints`);
+    }
+
+    if (effectiveScope.project) {
+      const beforeCount = dopplerTools.length;
+      dopplerTools = dopplerTools.filter(
+        (tool) =>
+          !ORG_LEVEL_ENDPOINT_PREFIXES.some((prefix) =>
+            tool.endpoint.startsWith(prefix),
+          ),
+      );
+      log(
+        `✓ Filtered out org-level tools: ${beforeCount} → ${dopplerTools.length} endpoints`,
+      );
+    }
+
+    if (effectiveScope.config) {
+      dopplerTools = dopplerTools.filter(
+        (tool) =>
+          tool.endpoint.includes("/configs/") ||
+          tool.name.includes("config") ||
+          tool.endpoint.includes("/secrets/") ||
+          tool.name.includes("secret"),
+      );
+      log(
+        `✓ Filtered for config-related tools: ${dopplerTools.length} endpoints`,
+      );
+    }
+
+    log("Generating MCP tools...");
+    const mcpTools = generator.generateTools(dopplerTools);
+    log(`✓ Generated ${mcpTools.length} MCP tools`);
+
+    const accessContext: AccessContext = {
+      tokenType,
+      readOnly: options.readOnly ?? false,
+      project: effectiveScope.project,
+      config: effectiveScope.config,
+    };
+    emitStartupMessages(accessContext);
+
+    const serverName = options.readOnly
+      ? "doppler-api-readonly"
+      : "doppler-api";
+    const server = new FastMCP({
+      name: serverName,
+      version: "1.0.0",
+    });
+
+    const confirmAccessTool = createConfirmAccessTool(accessContext);
+    if (confirmAccessTool) {
+      server.addTool(confirmAccessTool);
+    }
+
+    for (const tool of mcpTools) {
+      server.addTool(tool);
+    }
+
+    server.start({ transportType: "stdio" });
+
+    const modeText = options.readOnly ? " (Read-Only Mode)" : "";
+    log(`🚀 Doppler MCP Server started successfully!${modeText}`);
+    log(`📊 Available tools: ${mcpTools.length}`);
+    log(`🔗 Base URL: ${client.getBaseUrl()}`);
+
+    if (options.readOnly) {
+      log("🔒 Read-only mode: Only GET operations are available");
+    }
+    if (effectiveScope.project) {
+      log(`🎯 Project: ${effectiveScope.project}`);
+    }
+    if (effectiveScope.config) {
+      log(`🎯 Config: ${effectiveScope.config}`);
+    }
+
+    const exampleTools = dopplerTools.slice(0, 5);
+    log("\n📋 Example available tools:");
+    for (const tool of exampleTools) {
+      log(`  - ${tool.name}: ${tool.description}`);
+    }
+
+    if (dopplerTools.length > 5) {
+      log(`  ... and ${dopplerTools.length - 5} more tools`);
+    }
+
+    return server;
+  } catch (error) {
+    console.error("Failed to start Doppler MCP Server:", error);
+    process.exit(1);
+  }
+}
+
+process.on("SIGINT", () => {
+  console.error("\n👋 Shutting down Doppler MCP Server...");
+  process.exit(0);
+});
+
+process.on("SIGTERM", () => {
+  console.error("\n👋 Shutting down Doppler MCP Server...");
+  process.exit(0);
+});
+
+const options = parseCLIArgs();
+
+if (options.help) {
+  showHelp();
+  process.exit(0);
+}
+
+createDopplerMCPServer(options).catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});
+
+export { createDopplerMCPServer };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,312 @@
+import { z } from "zod";
+import {
+  OpenAPISpec,
+  Operation,
+  Parameter,
+  SchemaObject,
+  DopplerTool,
+} from "./types.js";
+
+export class OpenAPIParser {
+  private spec: OpenAPISpec;
+
+  constructor(spec: OpenAPISpec) {
+    this.spec = spec;
+  }
+
+  public parseToTools(): DopplerTool[] {
+    const tools: DopplerTool[] = [];
+
+    for (const [path, methods] of Object.entries(this.spec.paths)) {
+      for (const [method, operation] of Object.entries(methods)) {
+        if (operation.operationId && !operation.deprecated) {
+          const tool = this.createToolFromOperation(path, method, operation);
+          if (tool) {
+            tools.push(tool);
+          }
+        }
+      }
+    }
+
+    return tools;
+  }
+
+  private createToolFromOperation(
+    path: string,
+    method: string,
+    operation: Operation,
+  ): DopplerTool | null {
+    try {
+      const inputSchema = this.createInputSchema(operation);
+
+      return {
+        name: this.generateToolName(method, path, operation.operationId),
+        description:
+          operation.summary ||
+          operation.description ||
+          `${method.toUpperCase()} ${path}`,
+        inputSchema,
+        method: method.toUpperCase(),
+        endpoint: path,
+        parameters: operation.parameters || [],
+        requestBody: operation.requestBody,
+      };
+    } catch (error) {
+      console.warn(
+        `Failed to create tool for ${operation.operationId}:`,
+        error,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Generate a tool name using hybrid approach:
+   * - Use operationId if it's clean (semantic, not auto-generated)
+   * - Fall back to path-based generation for ugly operationIds
+   */
+  private generateToolName(
+    method: string,
+    path: string,
+    operationId: string,
+  ): string {
+    if (this.isCleanOperationId(operationId)) {
+      return this.sanitizeOperationId(operationId);
+    }
+    return this.generateFromPath(method, path);
+  }
+
+  /**
+   * Check if an operationId looks "clean" (semantic, not auto-generated).
+   * Clean examples: "workplace-get", "users_list", "secrets-download"
+   * Ugly examples: "get_v3workplacechange_requests", "post_v3configs"
+   */
+  private isCleanOperationId(operationId: string): boolean {
+    // Ugly indicators:
+    // 1. Contains "v3" (path leaked into operationId)
+    if (/v3/i.test(operationId)) return false;
+    // 2. Contains path params like {slug}
+    if (/\{[^}]+\}/.test(operationId)) return false;
+    // 3. Starts with HTTP method (get_, post_, put_, delete_, patch_)
+    if (/^(get|post|put|patch|delete)_/i.test(operationId)) return false;
+
+    return true;
+  }
+
+  /**
+   * Sanitize a clean operationId for use as a tool name.
+   */
+  private sanitizeOperationId(operationId: string): string {
+    let name = operationId
+      .replace(/-/g, "_")
+      // Remove path template variables like {service_account}
+      .replace(/\{[^}]+\}/g, "")
+      // Collapse multiple underscores
+      .replace(/_+/g, "_")
+      // Remove trailing underscores
+      .replace(/_$/, "");
+
+    // MCP tool names must be <= 64 characters
+    if (name.length > 64) {
+      name = name.substring(0, 64);
+      // Don't end on an underscore
+      name = name.replace(/_$/, "");
+    }
+
+    return name;
+  }
+
+  /**
+   * Generate a tool name from the HTTP method and path.
+   * Used as fallback when operationId is ugly/auto-generated.
+   */
+  private generateFromPath(method: string, path: string): string {
+    // 1. Strip /v3/ prefix
+    let cleanPath = path.replace(/^\/v3\//, "");
+
+    // 2. Split by / and process each segment
+    const segments = cleanPath.split("/").filter(Boolean);
+
+    // 3. Process segments: extract resource names, skip path params
+    const parts: string[] = [];
+    for (const seg of segments) {
+      // Path parameter like {project} - skip
+      if (seg.startsWith("{")) {
+        continue;
+      }
+      // Convert to snake_case
+      parts.push(seg.replace(/-/g, "_"));
+    }
+
+    // 4. Determine action suffix based on method and path structure
+    const endsWithParam = path.endsWith("}");
+    const methodUpper = method.toUpperCase();
+
+    let action: string;
+    switch (methodUpper) {
+      case "GET":
+        action = endsWithParam ? "get" : "list";
+        break;
+      case "POST":
+        action = "create";
+        break;
+      case "PUT":
+      case "PATCH":
+        action = "update";
+        break;
+      case "DELETE":
+        action = "delete";
+        break;
+      default:
+        action = method.toLowerCase();
+    }
+
+    // 5. Handle special action paths (e.g., /clone, /lock, /review)
+    const lastPart = parts[parts.length - 1];
+    const actionWords = [
+      "clone",
+      "lock",
+      "unlock",
+      "rollback",
+      "download",
+      "rename",
+      "close",
+      "apply",
+      "review",
+      "status",
+      "enable",
+      "disable",
+    ];
+    if (actionWords.includes(lastPart)) {
+      // For DELETE on action paths, use "{action}_delete" to avoid conflicts
+      if (methodUpper === "DELETE") {
+        action = `${lastPart}_delete`;
+      } else {
+        action = lastPart;
+      }
+      parts.pop();
+    }
+
+    // 6. Build the name
+    let name = parts.join("_");
+    if (!name.endsWith(`_${action}`) && !name.endsWith(action)) {
+      name = `${name}_${action}`;
+    }
+
+    // 7. Clean up
+    name = name.replace(/_+/g, "_").replace(/^_|_$/g, "");
+
+    // 8. Truncate to 64 chars (MCP limit)
+    if (name.length > 64) {
+      name = name.substring(0, 64).replace(/_$/, "");
+    }
+
+    return name;
+  }
+
+  private createInputSchema(operation: Operation): z.ZodSchema<any> {
+    const schemaFields: Record<string, z.ZodSchema<any>> = {};
+
+    if (operation.parameters) {
+      for (const param of operation.parameters) {
+        const zodSchema = this.convertSchemaToZod(param.schema);
+        schemaFields[param.name] = param.required
+          ? zodSchema
+          : zodSchema.optional();
+      }
+    }
+
+    if (operation.requestBody) {
+      const contentType = Object.keys(operation.requestBody.content)[0];
+      if (contentType === "application/json") {
+        const bodySchema = operation.requestBody.content[contentType].schema;
+        if (bodySchema && bodySchema.properties) {
+          for (const [propName, propSchema] of Object.entries(
+            bodySchema.properties,
+          )) {
+            const zodSchema = this.convertSchemaToZod(propSchema);
+            const isRequired = bodySchema.required?.includes(propName) ?? false;
+            schemaFields[propName] = isRequired
+              ? zodSchema
+              : zodSchema.optional();
+          }
+        }
+      }
+    }
+
+    // Use passthrough() to allow additional properties not in schema.
+    // OpenAPI specs often have example properties that shouldn't restrict input.
+    return z.object(schemaFields).passthrough();
+  }
+
+  private convertSchemaToZod(schema: SchemaObject): z.ZodSchema<any> {
+    if (schema.enum) {
+      const cleanedEnum = schema.enum.map((val: any) =>
+        typeof val === "string" ? val.replace(/^"|"$/g, "") : val,
+      );
+      return z.enum(cleanedEnum as [string, ...string[]]);
+    }
+
+    switch (schema.type) {
+      case "string":
+        if (schema.format === "json") {
+          return z.record(z.any());
+        }
+        let stringSchema = z.string();
+        if (schema.format === "email") {
+          stringSchema = stringSchema.email();
+        } else if (schema.format === "uri") {
+          stringSchema = stringSchema.url();
+        } else if (schema.pattern) {
+          stringSchema = stringSchema.regex(new RegExp(schema.pattern));
+        }
+        if (schema.minimum !== undefined) {
+          stringSchema = stringSchema.min(schema.minimum);
+        }
+        if (schema.maximum !== undefined) {
+          stringSchema = stringSchema.max(schema.maximum);
+        }
+        return stringSchema;
+
+      case "number":
+      case "integer":
+        let numberSchema =
+          schema.type === "integer" ? z.number().int() : z.number();
+        if (schema.minimum !== undefined) {
+          numberSchema = numberSchema.min(schema.minimum);
+        }
+        if (schema.maximum !== undefined) {
+          numberSchema = numberSchema.max(schema.maximum);
+        }
+        return numberSchema;
+
+      case "boolean":
+        return z.boolean();
+
+      case "array":
+        if (schema.items) {
+          return z.array(this.convertSchemaToZod(schema.items));
+        }
+        return z.array(z.any());
+
+      case "object":
+        if (schema.properties) {
+          const objectFields: Record<string, z.ZodSchema<any>> = {};
+          for (const [propName, propSchema] of Object.entries(
+            schema.properties,
+          )) {
+            const zodSchema = this.convertSchemaToZod(propSchema);
+            const isRequired = schema.required?.includes(propName) ?? false;
+            objectFields[propName] = isRequired
+              ? zodSchema
+              : zodSchema.optional();
+          }
+          return z.object(objectFields).passthrough();
+        }
+        return z.record(z.any());
+
+      default:
+        return z.any();
+    }
+  }
+}

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,0 +1,92 @@
+/**
+ * Implicit scope detection - enables better UX for scoped tokens where users
+ * don't need to specify --project and --config explicitly if the token can
+ * only access one of each.
+ */
+
+export type ScopeSource = "cli" | "token";
+
+export interface ScopeOptions {
+  project?: string;
+  projectSource?: ScopeSource;
+  config?: string;
+  configSource?: ScopeSource;
+}
+
+export interface ScopeClient {
+  listProjects(): Promise<Array<{ slug: string }>>;
+  listConfigs(project: string): Promise<Array<{ name: string; slug: string }>>;
+}
+
+export interface ImplicitScope {
+  project?: string;
+  config?: string;
+}
+
+export interface CLIScopeArgs {
+  project?: string;
+  config?: string;
+}
+
+export async function detectImplicitScope(
+  client: ScopeClient,
+): Promise<ImplicitScope> {
+  const scope: ImplicitScope = {};
+
+  const projects = await client.listProjects();
+  if (projects.length !== 1) {
+    return scope;
+  }
+
+  scope.project = projects[0].slug;
+
+  const configs = await client.listConfigs(scope.project);
+  if (configs.length === 1) {
+    scope.config = configs[0].name;
+  }
+
+  return scope;
+}
+
+/**
+ * CLI args take precedence. If CLI provides a different project than detected,
+ * the detected config is cleared (it was for a different project).
+ */
+export function mergeScope(
+  detected: ImplicitScope,
+  cliArgs: CLIScopeArgs,
+): ImplicitScope {
+  const effectiveProject = cliArgs.project ?? detected.project;
+
+  const projectChanged =
+    cliArgs.project !== undefined && cliArgs.project !== detected.project;
+
+  let effectiveConfig: string | undefined;
+  if (cliArgs.config !== undefined) {
+    effectiveConfig = cliArgs.config;
+  } else if (!projectChanged) {
+    effectiveConfig = detected.config;
+  }
+
+  return {
+    project: effectiveProject,
+    config: effectiveConfig,
+  };
+}
+
+export function validateScope(
+  detected: ImplicitScope,
+  cliArgs: CLIScopeArgs,
+): void {
+  if (cliArgs.config === undefined) {
+    return;
+  }
+
+  const effectiveProject = cliArgs.project ?? detected.project;
+
+  if (effectiveProject === undefined) {
+    throw new Error(
+      "--config requires --project (your token has access to multiple projects)",
+    );
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,80 @@
+import type { z } from "zod";
+
+export interface OpenAPISpec {
+  openapi: string;
+  info: {
+    title: string;
+    version: string;
+  };
+  servers: Array<{
+    url: string;
+  }>;
+  paths: Record<string, Record<string, Operation>>;
+  components?: {
+    schemas?: Record<string, any>;
+    securitySchemes?: Record<string, any>;
+  };
+}
+
+export interface Operation {
+  operationId: string;
+  summary?: string;
+  description?: string;
+  parameters?: Parameter[];
+  requestBody?: RequestBody;
+  responses: Record<string, Response>;
+  deprecated?: boolean;
+}
+
+export interface Parameter {
+  name: string;
+  in: "query" | "path" | "header" | "cookie";
+  required?: boolean;
+  schema: SchemaObject;
+  description?: string;
+}
+
+export interface RequestBody {
+  content: Record<
+    string,
+    {
+      schema: SchemaObject;
+    }
+  >;
+  required?: boolean;
+}
+
+export interface Response {
+  description: string;
+  content?: Record<
+    string,
+    {
+      schema?: SchemaObject;
+      examples?: Record<string, any>;
+    }
+  >;
+}
+
+export interface SchemaObject {
+  type?: string;
+  properties?: Record<string, SchemaObject>;
+  items?: SchemaObject;
+  required?: string[];
+  enum?: any[];
+  example?: any;
+  description?: string;
+  format?: string;
+  minimum?: number;
+  maximum?: number;
+  pattern?: string;
+}
+
+export interface DopplerTool {
+  name: string;
+  description: string;
+  inputSchema: z.ZodSchema<any>;
+  method: string;
+  endpoint: string;
+  parameters: Parameter[];
+  requestBody?: RequestBody;
+}

--- a/tests/access-warnings.test.ts
+++ b/tests/access-warnings.test.ts
@@ -1,0 +1,578 @@
+import { describe, it, expect } from "vitest";
+import { detectTokenType, type TokenType } from "../src/auth.js";
+import {
+  isProductionConfig,
+  getAccessMessages,
+  createConfirmAccessTool,
+  type AccessContext,
+  type AccessMessage,
+} from "../src/access-warnings.js";
+
+// =============================================================================
+// Token Type Detection
+// =============================================================================
+
+describe("detectTokenType", () => {
+  describe("service tokens (dp.st.*)", () => {
+    it("detects service tokens (project/config scoped)", () => {
+      expect(detectTokenType("dp.st.abc123")).toBe("service_token");
+      expect(detectTokenType("dp.st.xxx.yyy.zzz")).toBe("service_token");
+    });
+
+    it("handles minimal valid service token", () => {
+      expect(detectTokenType("dp.st.x")).toBe("service_token");
+    });
+  });
+
+  describe("service account tokens (dp.sa.*)", () => {
+    it("detects service account tokens (workspace automation)", () => {
+      expect(detectTokenType("dp.sa.abc123")).toBe("service_account");
+      expect(detectTokenType("dp.sa.xxx.yyy.zzz")).toBe("service_account");
+    });
+
+    it("handles minimal valid service account token", () => {
+      expect(detectTokenType("dp.sa.x")).toBe("service_account");
+    });
+  });
+
+  describe("SCIM tokens (dp.scim.*)", () => {
+    it("detects SCIM tokens", () => {
+      expect(detectTokenType("dp.scim.abc123")).toBe("scim");
+    });
+  });
+
+  describe("personal tokens (dp.pt.*)", () => {
+    it("detects personal tokens", () => {
+      expect(detectTokenType("dp.pt.abc123")).toBe("personal");
+      expect(detectTokenType("dp.pt.xxx.yyy")).toBe("personal");
+    });
+
+    it("handles minimal valid personal token", () => {
+      expect(detectTokenType("dp.pt.x")).toBe("personal");
+    });
+  });
+
+  describe("CLI tokens (dp.ct.*)", () => {
+    it("detects CLI tokens", () => {
+      expect(detectTokenType("dp.ct.abc123")).toBe("cli");
+      expect(detectTokenType("dp.ct.xxx.yyy")).toBe("cli");
+    });
+
+    it("handles minimal valid CLI token", () => {
+      expect(detectTokenType("dp.ct.x")).toBe("cli");
+    });
+  });
+
+  describe("unknown tokens", () => {
+    it("returns unknown for unrecognized prefixes", () => {
+      expect(detectTokenType("dp.xx.abc123")).toBe("unknown");
+      expect(detectTokenType("dp.personal.abc123")).toBe("unknown");
+      expect(detectTokenType("dp.foo.abc123")).toBe("unknown");
+    });
+
+    it("returns unknown for malformed tokens", () => {
+      expect(detectTokenType("invalid-token")).toBe("unknown");
+      expect(detectTokenType("not-a-doppler-token")).toBe("unknown");
+      expect(detectTokenType("abc123")).toBe("unknown");
+    });
+
+    it("returns unknown for empty or whitespace input", () => {
+      expect(detectTokenType("")).toBe("unknown");
+      expect(detectTokenType("   ")).toBe("unknown");
+    });
+
+    it("returns unknown for tokens missing required parts", () => {
+      expect(detectTokenType("dp.")).toBe("unknown");
+      expect(detectTokenType("dp")).toBe("unknown");
+      expect(detectTokenType("dp.st")).toBe("unknown"); // missing third part
+      expect(detectTokenType("dp.st.")).toBe("unknown"); // empty third part
+    });
+
+    it("returns unknown for tokens with wrong prefix", () => {
+      expect(detectTokenType("doppler.st.abc")).toBe("unknown");
+      expect(detectTokenType("DP.st.abc")).toBe("unknown"); // case sensitive
+      expect(detectTokenType("dpp.st.abc")).toBe("unknown");
+    });
+  });
+});
+
+// =============================================================================
+// Production Config Detection
+// =============================================================================
+
+describe("isProductionConfig", () => {
+  describe("exact production matches (case insensitive)", () => {
+    it.each(["prod", "prd", "production", "live"])(
+      'matches "%s" as production',
+      (config) => {
+        expect(isProductionConfig(config)).toBe(true);
+      },
+    );
+
+    it("matches regardless of case", () => {
+      expect(isProductionConfig("PROD")).toBe(true);
+      expect(isProductionConfig("Prod")).toBe(true);
+      expect(isProductionConfig("PRODUCTION")).toBe(true);
+      expect(isProductionConfig("Production")).toBe(true);
+      expect(isProductionConfig("LIVE")).toBe(true);
+      expect(isProductionConfig("Live")).toBe(true);
+      expect(isProductionConfig("PRD")).toBe(true);
+      expect(isProductionConfig("Prd")).toBe(true);
+    });
+  });
+
+  describe("suffix patterns with underscore", () => {
+    it.each([
+      "app_prod",
+      "app_prd",
+      "app_production",
+      "my_service_prod",
+      "api_prod",
+      "backend_production",
+    ])('matches "%s" as production', (config) => {
+      expect(isProductionConfig(config)).toBe(true);
+    });
+
+    it("matches suffix patterns case insensitively", () => {
+      expect(isProductionConfig("APP_PROD")).toBe(true);
+      expect(isProductionConfig("App_Prod")).toBe(true);
+      expect(isProductionConfig("app_PRODUCTION")).toBe(true);
+    });
+  });
+
+  describe("suffix patterns with hyphen", () => {
+    it.each([
+      "app-prod",
+      "app-prd",
+      "app-production",
+      "my-service-prod",
+      "api-prod",
+      "backend-production",
+    ])('matches "%s" as production', (config) => {
+      expect(isProductionConfig(config)).toBe(true);
+    });
+
+    it("matches hyphen suffix patterns case insensitively", () => {
+      expect(isProductionConfig("APP-PROD")).toBe(true);
+      expect(isProductionConfig("App-Prod")).toBe(true);
+      expect(isProductionConfig("app-PRODUCTION")).toBe(true);
+    });
+  });
+
+  describe("non-production configs", () => {
+    it.each([
+      "dev",
+      "development",
+      "staging",
+      "stg",
+      "test",
+      "testing",
+      "qa",
+      "sandbox",
+      "local",
+      "ci",
+      "preview",
+    ])('does not match "%s" as production', (config) => {
+      expect(isProductionConfig(config)).toBe(false);
+    });
+
+    it("does not match when prod is a prefix, not suffix", () => {
+      expect(isProductionConfig("prod_backup")).toBe(false);
+      expect(isProductionConfig("production_old")).toBe(false);
+      expect(isProductionConfig("prod-backup")).toBe(false);
+      expect(isProductionConfig("production-archive")).toBe(false);
+    });
+
+    it("does not match when prod is a substring", () => {
+      expect(isProductionConfig("reproduce")).toBe(false);
+      expect(isProductionConfig("my-product")).toBe(false);
+      expect(isProductionConfig("productivity")).toBe(false);
+      expect(isProductionConfig("introduction")).toBe(false);
+    });
+
+    it("does not match development environments with similar naming", () => {
+      expect(isProductionConfig("dev_prod_mirror")).toBe(false); // prod in middle
+      expect(isProductionConfig("preprod")).toBe(false); // prefix without separator
+      expect(isProductionConfig("nonprod")).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty string", () => {
+      expect(isProductionConfig("")).toBe(false);
+    });
+
+    it("handles whitespace", () => {
+      expect(isProductionConfig("   ")).toBe(false);
+      expect(isProductionConfig(" prod ")).toBe(false); // has spaces
+    });
+
+    it("handles special characters", () => {
+      expect(isProductionConfig("prod!")).toBe(false);
+      expect(isProductionConfig("prod@live")).toBe(false);
+    });
+  });
+});
+
+// =============================================================================
+// Access Messages Generation
+// =============================================================================
+
+describe("getAccessMessages", () => {
+  // ---------------------------------------------------------------------------
+  // Info-level messages (always shown, no confirmation needed)
+  // ---------------------------------------------------------------------------
+  describe("scope info messages", () => {
+    it("includes token type info for all known token types", () => {
+      const knownTypes: TokenType[] = [
+        "service_token",
+        "service_account",
+        "personal",
+        "cli",
+        "scim",
+      ];
+
+      for (const tokenType of knownTypes) {
+        const ctx: AccessContext = {
+          tokenType,
+          readOnly: true,
+          project: "my-app",
+        };
+
+        const messages = getAccessMessages(ctx);
+        const tokenInfo = messages.find(
+          (m) => m.level === "info" && m.message.includes("Token type"),
+        );
+
+        expect(tokenInfo).toBeDefined();
+        expect(tokenInfo?.emoji).toBe("ℹ️");
+      }
+    });
+
+    it("includes project scope info when project is set", () => {
+      const ctx: AccessContext = {
+        tokenType: "service_token",
+        readOnly: true,
+        project: "my-app",
+      };
+
+      const messages = getAccessMessages(ctx);
+
+      expect(messages).toContainEqual({
+        level: "info",
+        emoji: "ℹ️",
+        message: "Project: my-app",
+      });
+    });
+
+    it("includes config scope info when config is set", () => {
+      const ctx: AccessContext = {
+        tokenType: "service_token",
+        readOnly: true,
+        project: "my-app",
+        config: "development",
+      };
+
+      const messages = getAccessMessages(ctx);
+
+      expect(messages).toContainEqual({
+        level: "info",
+        emoji: "ℹ️",
+        message: "Config: development",
+      });
+    });
+
+    it("includes read-only info when in read-only mode", () => {
+      const ctx: AccessContext = {
+        tokenType: "service_token",
+        readOnly: true,
+        project: "my-app",
+      };
+
+      const messages = getAccessMessages(ctx);
+
+      expect(messages).toContainEqual({
+        level: "info",
+        emoji: "ℹ️",
+        message: "Mode: read-only",
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Critical-level messages (require confirmation)
+  // ---------------------------------------------------------------------------
+  describe("critical messages", () => {
+    it("emits critical message for unknown token type", () => {
+      const ctx: AccessContext = {
+        tokenType: "unknown",
+        readOnly: true,
+        project: "my-app",
+      };
+
+      const messages = getAccessMessages(ctx);
+
+      expect(messages).toContainEqual({
+        level: "critical",
+        emoji: "🚨",
+        message: expect.stringContaining("UNKNOWN TOKEN TYPE"),
+      });
+    });
+
+    it("emits critical message for SCIM token type", () => {
+      const ctx: AccessContext = {
+        tokenType: "scim",
+        readOnly: true,
+        project: "my-app",
+      };
+
+      const messages = getAccessMessages(ctx);
+
+      expect(messages).toContainEqual({
+        level: "critical",
+        emoji: "🚨",
+        message: expect.stringContaining("SCIM TOKEN"),
+      });
+    });
+
+    it("emits critical message for production configs", () => {
+      const ctx: AccessContext = {
+        tokenType: "service_token",
+        readOnly: false,
+        project: "my-app",
+        config: "production",
+      };
+
+      const messages = getAccessMessages(ctx);
+
+      expect(messages).toContainEqual({
+        level: "critical",
+        emoji: "🚨",
+        message: expect.stringContaining("PRODUCTION CONFIG"),
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Warning-level messages (require confirmation)
+  // ---------------------------------------------------------------------------
+  describe("warning messages", () => {
+    it("emits warning for write access enabled", () => {
+      const ctx: AccessContext = {
+        tokenType: "service_token",
+        readOnly: false,
+        project: "my-app",
+      };
+
+      const messages = getAccessMessages(ctx);
+
+      expect(messages).toContainEqual({
+        level: "warning",
+        emoji: "⚠️",
+        message: expect.stringContaining("Write tools exposed"),
+      });
+    });
+
+    it("emits warning when no project scope (full workspace access)", () => {
+      const ctx: AccessContext = {
+        tokenType: "service_account",
+        readOnly: true,
+      };
+
+      const messages = getAccessMessages(ctx);
+
+      expect(messages).toContainEqual({
+        level: "warning",
+        emoji: "⚠️",
+        message: expect.stringContaining("No project filter applied"),
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Safe mode (info only, no warnings or critical)
+  // ---------------------------------------------------------------------------
+  describe("safe mode", () => {
+    it("returns only info messages for fully safe config", () => {
+      const ctx: AccessContext = {
+        tokenType: "service_token",
+        readOnly: true,
+        project: "my-app",
+        config: "development",
+      };
+
+      const messages = getAccessMessages(ctx);
+      const nonInfoMessages = messages.filter((m) => m.level !== "info");
+
+      expect(nonInfoMessages).toHaveLength(0);
+      expect(messages.length).toBeGreaterThan(0); // Should still have info messages
+    });
+
+    it("includes all scope info even in safe mode", () => {
+      const ctx: AccessContext = {
+        tokenType: "service_token",
+        readOnly: true,
+        project: "my-app",
+        config: "development",
+      };
+
+      const messages = getAccessMessages(ctx);
+      const infoMessages = messages.filter((m) => m.level === "info");
+
+      // Should have: token type, project, config, mode
+      expect(infoMessages.length).toBeGreaterThanOrEqual(4);
+    });
+  });
+});
+
+// =============================================================================
+// Confirm Access Tool
+// =============================================================================
+
+describe("createConfirmAccessTool", () => {
+  it("returns null when only info-level messages (safe mode)", () => {
+    const ctx: AccessContext = {
+      tokenType: "service_token",
+      readOnly: true,
+      project: "my-app",
+      config: "development",
+    };
+
+    const tool = createConfirmAccessTool(ctx);
+
+    // Info messages exist but don't trigger confirmation
+    expect(tool).toBeNull();
+  });
+
+  it("returns tool when there are warning-level messages", () => {
+    const ctx: AccessContext = {
+      tokenType: "service_token",
+      readOnly: false, // This triggers a warning
+      project: "my-app",
+    };
+
+    const tool = createConfirmAccessTool(ctx);
+
+    expect(tool).not.toBeNull();
+    expect(tool?.name).toBe("confirm_access");
+  });
+
+  it("returns tool when there are critical-level messages", () => {
+    const ctx: AccessContext = {
+      tokenType: "unknown", // This triggers a critical
+      readOnly: true,
+      project: "my-app",
+    };
+
+    const tool = createConfirmAccessTool(ctx);
+
+    expect(tool).not.toBeNull();
+    expect(tool?.name).toBe("confirm_access");
+  });
+
+  it("tool description indicates it is required first step", () => {
+    const ctx: AccessContext = {
+      tokenType: "service_account",
+      readOnly: false,
+    };
+
+    const tool = createConfirmAccessTool(ctx);
+
+    expect(tool?.description).toContain("REQUIRED FIRST STEP");
+  });
+
+  it("tool execute includes both scope info and warnings", async () => {
+    const ctx: AccessContext = {
+      tokenType: "service_token",
+      readOnly: false,
+      project: "my-app",
+    };
+
+    const tool = createConfirmAccessTool(ctx);
+    const result = await tool?.execute({});
+
+    // XML structure
+    expect(result).toContain("<security_confirmation");
+    expect(result).toContain("<display_to_user>");
+    // Should contain scope info section
+    expect(result).toContain("ℹ️");
+    expect(result).toContain("Project: my-app");
+    expect(result).toContain("Token type:");
+    // Should contain warnings section
+    expect(result).toContain("Write tools exposed");
+    expect(result).toContain("Do you want me to proceed?");
+  });
+
+  it("tool execute shows all scope info even with multiple warnings", async () => {
+    const ctx: AccessContext = {
+      tokenType: "unknown",
+      readOnly: false,
+      config: "production",
+    };
+
+    const tool = createConfirmAccessTool(ctx);
+    const result = await tool?.execute({});
+
+    // Scope info
+    expect(result).toContain("Token type:");
+    expect(result).toContain("Config: production");
+    // Warnings
+    expect(result).toContain("UNKNOWN TOKEN TYPE");
+    expect(result).toContain("Write tools exposed");
+    expect(result).toContain("No project filter applied");
+    expect(result).toContain("PRODUCTION CONFIG");
+  });
+
+  it("tool includes production warning when connected to production", async () => {
+    const ctx: AccessContext = {
+      tokenType: "service_token",
+      readOnly: false,
+      project: "my-app",
+      config: "prod",
+    };
+
+    const tool = createConfirmAccessTool(ctx);
+    const result = await tool?.execute({});
+
+    expect(result).toContain("PRODUCTION CONFIG");
+  });
+});
+
+// =============================================================================
+// Combined Scenarios
+// =============================================================================
+
+describe("combined scenarios", () => {
+  it("safest config: read-only + project-scoped + service_token + non-prod", () => {
+    const ctx: AccessContext = {
+      tokenType: "service_token",
+      readOnly: true,
+      project: "my-app",
+      config: "development",
+    };
+
+    const messages = getAccessMessages(ctx);
+    const tool = createConfirmAccessTool(ctx);
+
+    // All messages should be info level
+    expect(messages.every((m) => m.level === "info")).toBe(true);
+    expect(messages.length).toBeGreaterThan(0);
+    expect(tool).toBeNull();
+  });
+
+  it("riskiest config: write + no scope + unknown token + production", () => {
+    const ctx: AccessContext = {
+      tokenType: "unknown",
+      readOnly: false,
+      config: "production",
+    };
+
+    const messages = getAccessMessages(ctx);
+    const tool = createConfirmAccessTool(ctx);
+
+    // Should have warnings and criticals
+    expect(messages.some((m) => m.level === "warning")).toBe(true);
+    expect(messages.some((m) => m.level === "critical")).toBe(true);
+    expect(tool).not.toBeNull();
+  });
+});

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { detectTokenType, type TokenType } from "../src/auth.js";
+
+describe("detectTokenType", () => {
+  describe("service tokens (dp.st.*)", () => {
+    it("detects service tokens (project/config scoped)", () => {
+      expect(detectTokenType("dp.st.abc123")).toBe("service_token");
+      expect(detectTokenType("dp.st.xxx.yyy.zzz")).toBe("service_token");
+    });
+
+    it("handles minimal valid service token", () => {
+      expect(detectTokenType("dp.st.x")).toBe("service_token");
+    });
+  });
+
+  describe("service account tokens (dp.sa.*)", () => {
+    it("detects service account tokens (workspace automation)", () => {
+      expect(detectTokenType("dp.sa.abc123")).toBe("service_account");
+      expect(detectTokenType("dp.sa.xxx.yyy.zzz")).toBe("service_account");
+    });
+
+    it("handles minimal valid service account token", () => {
+      expect(detectTokenType("dp.sa.x")).toBe("service_account");
+    });
+  });
+
+  describe("SCIM tokens (dp.scim.*)", () => {
+    it("detects SCIM tokens", () => {
+      expect(detectTokenType("dp.scim.abc123")).toBe("scim");
+    });
+  });
+
+  describe("personal tokens (dp.pt.*)", () => {
+    it("detects personal tokens", () => {
+      expect(detectTokenType("dp.pt.abc123")).toBe("personal");
+    });
+  });
+
+  describe("CLI tokens (dp.ct.*)", () => {
+    it("detects CLI tokens", () => {
+      expect(detectTokenType("dp.ct.abc123")).toBe("cli");
+    });
+  });
+
+  describe("unknown tokens", () => {
+    it("returns unknown for unrecognized prefixes", () => {
+      expect(detectTokenType("dp.xx.abc123")).toBe("unknown");
+    });
+
+    it("returns unknown for malformed tokens", () => {
+      expect(detectTokenType("invalid-token")).toBe("unknown");
+      expect(detectTokenType("")).toBe("unknown");
+    });
+
+    it("returns unknown for tokens missing required parts", () => {
+      expect(detectTokenType("dp.st")).toBe("unknown");
+      expect(detectTokenType("dp.st.")).toBe("unknown");
+    });
+  });
+});

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { ScopeViolationError } from "../src/errors.js";
+
+describe("ScopeViolationError", () => {
+  it("is an instance of Error", () => {
+    const error = new ScopeViolationError("test message");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("has the correct name", () => {
+    const error = new ScopeViolationError("test message");
+    expect(error.name).toBe("ScopeViolationError");
+  });
+
+  it("preserves the message", () => {
+    const error = new ScopeViolationError("Project scope violation");
+    expect(error.message).toBe("Project scope violation");
+  });
+
+  it("can be caught as Error", () => {
+    const error = new ScopeViolationError("test");
+
+    try {
+      throw error;
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect(e).toBeInstanceOf(ScopeViolationError);
+    }
+  });
+});

--- a/tests/filters.test.ts
+++ b/tests/filters.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDopplerAPI, filterTestOpenAPISpec } from "./helpers.js";
+
+const mockFetch = vi.fn();
+const originalFetch = global.fetch;
+const originalEnv = { ...process.env };
+
+/**
+ * Filter tests use filterTestOpenAPISpec which has:
+ * - 11 total tools
+ * - Org-level: /v3/workplace/*, /v3/logs (4 tools)
+ * - Project-level: /v3/projects, /v3/environments (3 tools)
+ * - Config-level: /v3/configs/*, /v3/configs/config/secrets (4 tools)
+ * - GET methods: 7, POST methods: 4
+ */
+describe("CLI filter flags", () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.DOPPLER_TOKEN = "dp.st.test_token";
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+
+    vi.resetModules();
+
+    vi.doMock("fs", () => ({
+      readFileSync: () => JSON.stringify(filterTestOpenAPISpec),
+    }));
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  describe("--read-only", () => {
+    it("only includes GET methods", async () => {
+      mockDopplerAPI(mockFetch, {
+        projects: ["my-app"],
+        configs: { "my-app": ["dev"] },
+      });
+
+      const { createDopplerMCPServer } = await import("../src/index.js");
+
+      // Capture tool registrations by inspecting what gets logged
+      const consoleOutput: string[] = [];
+      const originalError = console.error;
+      console.error = (...args) => consoleOutput.push(args.join(" "));
+
+      await createDopplerMCPServer({ readOnly: true, verbose: true });
+
+      console.error = originalError;
+
+      // Parse logged output to verify filtering
+      const output = consoleOutput.join("\n");
+      expect(output).toMatch(/read-only/i);
+
+      // The key assertion: filtered count < total count
+      const filteredMatch = output.match(/(\d+) read-only endpoints/);
+      const totalMatch = output.match(/Parsed (\d+) API endpoints/);
+
+      // With filterTestOpenAPISpec: 7 GET, 4 POST = 11 total, 7 read-only
+      expect(filteredMatch).toBeTruthy();
+      const filteredCount = parseInt(filteredMatch![1]);
+      expect(filteredCount).toBeLessThan(11); // Less than total
+      expect(filteredCount).toBeGreaterThan(0); // But not zero
+    });
+  });
+
+  describe("--project", () => {
+    it("filters out org-level endpoints", async () => {
+      mockDopplerAPI(mockFetch, {
+        projects: ["my-app"],
+        configs: { "my-app": ["dev"] },
+      });
+
+      const { createDopplerMCPServer } = await import("../src/index.js");
+
+      const consoleOutput: string[] = [];
+      const originalError = console.error;
+      console.error = (...args) => consoleOutput.push(args.join(" "));
+
+      await createDopplerMCPServer({ project: "my-app", verbose: true });
+
+      console.error = originalError;
+
+      const output = consoleOutput.join("\n");
+
+      // Should log filtering action
+      expect(output).toMatch(/org-level/i);
+
+      // Should show reduction: "11 → 7" (filters out 4 org-level tools)
+      const filterMatch = output.match(/(\d+) → (\d+) endpoints/);
+      expect(filterMatch).toBeTruthy();
+      const [, before, after] = filterMatch!;
+      expect(parseInt(after)).toBeLessThan(parseInt(before));
+    });
+  });
+
+  describe("--config", () => {
+    it("keeps only config and secret related tools", async () => {
+      mockDopplerAPI(mockFetch, {
+        projects: ["my-app"],
+        configs: { "my-app": ["production"] },
+      });
+
+      const { createDopplerMCPServer } = await import("../src/index.js");
+
+      const consoleOutput: string[] = [];
+      const originalError = console.error;
+      console.error = (...args) => consoleOutput.push(args.join(" "));
+
+      await createDopplerMCPServer({
+        project: "my-app",
+        config: "production",
+        verbose: true,
+      });
+
+      console.error = originalError;
+
+      const output = consoleOutput.join("\n");
+
+      // Should log config filtering
+      expect(output).toMatch(/config-related/i);
+
+      // With filterTestOpenAPISpec: should reduce to 4 config/secret tools
+      const filterMatch = output.match(/config-related tools: (\d+) endpoints/);
+      expect(filterMatch).toBeTruthy();
+      const configToolCount = parseInt(filterMatch![1]);
+      expect(configToolCount).toBeLessThan(11); // Less than total
+      expect(configToolCount).toBeGreaterThan(0); // But not zero
+    });
+  });
+
+  describe("combined filters", () => {
+    it("--read-only + --project applies both filters", async () => {
+      mockDopplerAPI(mockFetch, {
+        projects: ["my-app"],
+        configs: { "my-app": ["dev"] },
+      });
+
+      const { createDopplerMCPServer } = await import("../src/index.js");
+
+      const consoleOutput: string[] = [];
+      const originalError = console.error;
+      console.error = (...args) => consoleOutput.push(args.join(" "));
+
+      await createDopplerMCPServer({
+        readOnly: true,
+        project: "my-app",
+        verbose: true,
+      });
+
+      console.error = originalError;
+
+      const output = consoleOutput.join("\n");
+
+      // Both filters should be mentioned
+      expect(output).toMatch(/read-only/i);
+      expect(output).toMatch(/org-level/i);
+    });
+  });
+});

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -1,0 +1,716 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ToolGenerator } from "../src/generator.js";
+import type { DopplerTool, Parameter } from "../src/types.js";
+import { ScopeViolationError } from "../src/errors.js";
+import { z } from "zod";
+
+const mockMakeRequest = vi.fn();
+
+const createMockClient = () => ({
+  makeRequest: mockMakeRequest,
+  getBaseUrl: () => "https://api.doppler.com",
+  testConnection: vi.fn(),
+});
+
+const createMockTool = (overrides: Partial<DopplerTool> = {}): DopplerTool => ({
+  name: "test_tool",
+  description: "A test tool",
+  inputSchema: z.object({
+    project: z.string(),
+    config: z.string().optional(),
+  }),
+  method: "GET",
+  endpoint: "/v3/test",
+  parameters: [
+    {
+      name: "project",
+      in: "query",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "config",
+      in: "query",
+      required: false,
+      schema: { type: "string" },
+    },
+  ] as Parameter[],
+  ...overrides,
+});
+
+describe("ToolGenerator", () => {
+  beforeEach(() => {
+    mockMakeRequest.mockReset();
+    mockMakeRequest.mockResolvedValue({ success: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("generateTools", () => {
+    it("generates MCP tools from DopplerTool definitions", () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any);
+
+      const dopplerTools = [
+        createMockTool({ name: "projects_list", endpoint: "/v3/projects" }),
+        createMockTool({ name: "configs_list", endpoint: "/v3/configs" }),
+      ];
+
+      const mcpTools = generator.generateTools(dopplerTools);
+
+      expect(mcpTools).toHaveLength(2);
+      expect(mcpTools[0].name).toBe("projects_list");
+      expect(mcpTools[1].name).toBe("configs_list");
+    });
+
+    it("includes description in generated tools", () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any);
+
+      const dopplerTools = [
+        createMockTool({
+          name: "workplace_get",
+          description: "Retrieve workplace information",
+        }),
+      ];
+
+      const mcpTools = generator.generateTools(dopplerTools);
+
+      expect(mcpTools[0].description).toBe("Retrieve workplace information");
+    });
+
+    it("includes input schema parameters in generated tools", () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any);
+
+      const dopplerTools = [createMockTool()];
+      const mcpTools = generator.generateTools(dopplerTools);
+
+      expect(mcpTools[0].parameters).toBeDefined();
+    });
+  });
+
+  describe("tool execution", () => {
+    it("makes GET request with correct endpoint", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any);
+
+      const tool = createMockTool({
+        name: "workplace_get",
+        method: "GET",
+        endpoint: "/v3/workplace",
+        parameters: [],
+        inputSchema: z.object({}),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+      await mcpTools[0].execute({});
+
+      expect(mockMakeRequest).toHaveBeenCalledWith({
+        method: "GET",
+        endpoint: "/v3/workplace",
+        queryParams: {},
+        body: undefined,
+      });
+    });
+
+    it("includes query parameters in the request", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any);
+
+      const tool = createMockTool({
+        name: "configs_list",
+        method: "GET",
+        endpoint: "/v3/configs",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+      await mcpTools[0].execute({ project: "my-project" });
+
+      expect(mockMakeRequest).toHaveBeenCalledWith({
+        method: "GET",
+        endpoint: "/v3/configs",
+        queryParams: { project: "my-project" },
+        body: undefined,
+      });
+    });
+
+    it("substitutes path parameters in endpoint URL", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any);
+
+      const tool = createMockTool({
+        name: "projects_get",
+        method: "GET",
+        endpoint: "/v3/projects/{project}",
+        parameters: [
+          {
+            name: "project",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+      await mcpTools[0].execute({ project: "my-project" });
+
+      expect(mockMakeRequest).toHaveBeenCalledWith({
+        method: "GET",
+        endpoint: "/v3/projects/my-project",
+        queryParams: {},
+        body: undefined,
+      });
+    });
+
+    it("URL-encodes path parameters", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any);
+
+      const tool = createMockTool({
+        name: "projects_get",
+        method: "GET",
+        endpoint: "/v3/projects/{project}",
+        parameters: [
+          {
+            name: "project",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+      await mcpTools[0].execute({ project: "my project/special" });
+
+      expect(mockMakeRequest).toHaveBeenCalledWith({
+        method: "GET",
+        endpoint: "/v3/projects/my%20project%2Fspecial",
+        queryParams: {},
+        body: undefined,
+      });
+    });
+
+    it("includes request body for POST requests", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any);
+
+      const tool = createMockTool({
+        name: "projects_create",
+        method: "POST",
+        endpoint: "/v3/projects",
+        parameters: [],
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  description: { type: "string" },
+                },
+                required: ["name"],
+              },
+            },
+          },
+        },
+        inputSchema: z.object({
+          name: z.string(),
+          description: z.string().optional(),
+        }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+      await mcpTools[0].execute({
+        name: "New Project",
+        description: "A test project",
+      });
+
+      expect(mockMakeRequest).toHaveBeenCalledWith({
+        method: "POST",
+        endpoint: "/v3/projects",
+        queryParams: {},
+        body: { name: "New Project", description: "A test project" },
+      });
+    });
+
+    it("preserves additional body properties not defined in schema", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any);
+
+      // Simulates the secrets endpoint where schema has example keys
+      // but users can provide arbitrary secret names
+      const tool = createMockTool({
+        name: "secrets_update",
+        method: "POST",
+        endpoint: "/v3/configs/config/secrets",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "config",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  // Schema only defines example properties
+                  secrets: {
+                    type: "object",
+                    properties: {
+                      EXAMPLE_KEY: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        inputSchema: z
+          .object({
+            project: z.string(),
+            config: z.string(),
+            secrets: z.object({}).passthrough(),
+          })
+          .passthrough(),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+      await mcpTools[0].execute({
+        project: "my-app",
+        config: "dev",
+        secrets: {
+          MY_CUSTOM_SECRET: "secret-value",
+          ANOTHER_SECRET: "another-value",
+        },
+      });
+
+      expect(mockMakeRequest).toHaveBeenCalledWith({
+        method: "POST",
+        endpoint: "/v3/configs/config/secrets",
+        queryParams: { project: "my-app", config: "dev" },
+        body: {
+          secrets: {
+            MY_CUSTOM_SECRET: "secret-value",
+            ANOTHER_SECRET: "another-value",
+          },
+        },
+      });
+    });
+
+    it("preserves top-level body properties not in schema", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any);
+
+      const tool = createMockTool({
+        name: "endpoint_create",
+        method: "POST",
+        endpoint: "/v3/endpoint",
+        parameters: [],
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        inputSchema: z.object({ name: z.string() }).passthrough(),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+      await mcpTools[0].execute({
+        name: "test",
+        extraField: "should-be-preserved",
+        anotherExtra: 123,
+      });
+
+      expect(mockMakeRequest).toHaveBeenCalledWith({
+        method: "POST",
+        endpoint: "/v3/endpoint",
+        queryParams: {},
+        body: {
+          name: "test",
+          extraField: "should-be-preserved",
+          anotherExtra: 123,
+        },
+      });
+    });
+  });
+
+  describe("auto-injection of parameters", () => {
+    it("auto-injects project parameter when configured", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any, {
+        project: "injected-project",
+      });
+
+      const tool = createMockTool({
+        name: "configs_list",
+        method: "GET",
+        endpoint: "/v3/configs",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string().optional() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+      await mcpTools[0].execute({});
+
+      expect(mockMakeRequest).toHaveBeenCalledWith({
+        method: "GET",
+        endpoint: "/v3/configs",
+        queryParams: { project: "injected-project" },
+        body: undefined,
+      });
+    });
+
+    it("auto-injects config parameter when configured", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any, {
+        config: "production",
+      });
+
+      const tool = createMockTool({
+        name: "secrets_list",
+        method: "GET",
+        endpoint: "/v3/configs/config/secrets",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "config",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({
+          project: z.string(),
+          config: z.string().optional(),
+        }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+      await mcpTools[0].execute({ project: "my-project" });
+
+      expect(mockMakeRequest).toHaveBeenCalledWith({
+        method: "GET",
+        endpoint: "/v3/configs/config/secrets",
+        queryParams: { project: "my-project", config: "production" },
+        body: undefined,
+      });
+    });
+
+    it("allows explicitly provided parameters that match configured scope", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any, {
+        project: "my-project",
+        config: "production",
+      });
+
+      const tool = createMockTool({
+        name: "secrets_list",
+        method: "GET",
+        endpoint: "/v3/configs/config/secrets",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "config",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string(), config: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+      // Same values as configured - should work
+      await mcpTools[0].execute({
+        project: "my-project",
+        config: "production",
+      });
+
+      expect(mockMakeRequest).toHaveBeenCalledWith({
+        method: "GET",
+        endpoint: "/v3/configs/config/secrets",
+        queryParams: {
+          project: "my-project",
+          config: "production",
+        },
+        body: undefined,
+      });
+    });
+  });
+
+  describe("scope enforcement", () => {
+    it("rejects project parameter that differs from CLI-configured scope", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any, {
+        project: "allowed-project",
+        projectSource: "cli",
+      });
+
+      const tool = createMockTool({
+        name: "configs_list",
+        method: "GET",
+        endpoint: "/v3/configs",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+
+      await expect(
+        mcpTools[0].execute({ project: "different-project" }),
+      ).rejects.toThrow(/configured for project/i);
+    });
+
+    it("rejects project parameter with token-specific message when token-scoped", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any, {
+        project: "allowed-project",
+        projectSource: "token",
+      });
+
+      const tool = createMockTool({
+        name: "configs_list",
+        method: "GET",
+        endpoint: "/v3/configs",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+
+      await expect(
+        mcpTools[0].execute({ project: "different-project" }),
+      ).rejects.toThrow(/token only has access to project/i);
+    });
+
+    it("rejects config parameter that differs from CLI-configured scope", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any, {
+        project: "my-project",
+        config: "production",
+        configSource: "cli",
+      });
+
+      const tool = createMockTool({
+        name: "secrets_list",
+        method: "GET",
+        endpoint: "/v3/configs/config/secrets",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "config",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string(), config: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+
+      await expect(
+        mcpTools[0].execute({ project: "my-project", config: "staging" }),
+      ).rejects.toThrow(/configured for config/i);
+    });
+
+    it("rejects config parameter with token-specific message when token-scoped", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any, {
+        project: "my-project",
+        config: "ci",
+        configSource: "token",
+      });
+
+      const tool = createMockTool({
+        name: "secrets_list",
+        method: "GET",
+        endpoint: "/v3/configs/config/secrets",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "config",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string(), config: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+
+      await expect(
+        mcpTools[0].execute({ project: "my-project", config: "dev" }),
+      ).rejects.toThrow(/token only has access to config/i);
+    });
+
+    it("includes helpful error message with configured and requested values", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any, {
+        project: "content-api",
+        projectSource: "cli",
+      });
+
+      const tool = createMockTool({
+        name: "secrets_list",
+        method: "GET",
+        endpoint: "/v3/configs/config/secrets",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+
+      await expect(
+        mcpTools[0].execute({ project: "marketing-api" }),
+      ).rejects.toThrow(/content-api.*marketing-api/);
+    });
+
+    it("throws ScopeViolationError for project violations", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any, {
+        project: "allowed-project",
+        projectSource: "cli",
+      });
+
+      const tool = createMockTool({
+        name: "configs_list",
+        method: "GET",
+        endpoint: "/v3/configs",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+
+      await expect(
+        mcpTools[0].execute({ project: "different-project" }),
+      ).rejects.toThrow(ScopeViolationError);
+    });
+
+    it("throws ScopeViolationError for config violations", async () => {
+      const client = createMockClient();
+      const generator = new ToolGenerator(client as any, {
+        project: "my-project",
+        config: "production",
+        configSource: "token",
+      });
+
+      const tool = createMockTool({
+        name: "secrets_list",
+        method: "GET",
+        endpoint: "/v3/configs/config/secrets",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "config",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ] as Parameter[],
+        inputSchema: z.object({ project: z.string(), config: z.string() }),
+      });
+
+      const mcpTools = generator.generateTools([tool]);
+
+      await expect(
+        mcpTools[0].execute({ project: "my-project", config: "staging" }),
+      ).rejects.toThrow(ScopeViolationError);
+    });
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,215 @@
+import { vi } from "vitest";
+
+export const jsonResponse = (data: unknown) => ({
+  ok: true,
+  headers: {
+    get: (h: string) => (h === "content-type" ? "application/json" : null),
+  },
+  json: async () => data,
+});
+
+export function mockDopplerAPI(
+  mockFetch: ReturnType<typeof vi.fn>,
+  options: {
+    projects: string[];
+    configs?: Record<string, string[]>;
+  },
+) {
+  mockFetch.mockImplementation(async (url: string) => {
+    const urlStr = url.toString();
+
+    if (urlStr.includes("/v3/workplace")) {
+      return jsonResponse({ workplace: { name: "Test Workplace" } });
+    }
+
+    if (urlStr.includes("/v3/projects") && !urlStr.includes("/v3/projects/")) {
+      return jsonResponse({
+        projects: options.projects.map((slug) => ({ slug, name: slug })),
+      });
+    }
+
+    if (urlStr.includes("/v3/configs")) {
+      const project = urlStr.match(/project=([^&]+)/)?.[1] ?? "";
+      return jsonResponse({
+        configs: (options.configs?.[project] ?? []).map((slug) => ({
+          slug,
+          name: slug,
+        })),
+      });
+    }
+
+    return { ok: false, status: 404, statusText: "Not Found" };
+  });
+}
+
+export const minimalOpenAPISpec = {
+  openapi: "3.0.0",
+  info: { title: "Doppler API", version: "1.0.0" },
+  servers: [{ url: "https://api.doppler.com" }],
+  paths: {
+    "/v3/workplace": {
+      get: {
+        operationId: "workplace-get",
+        summary: "Get workplace",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+    "/v3/projects": {
+      get: {
+        operationId: "projects-list",
+        summary: "List projects",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+    "/v3/configs": {
+      get: {
+        operationId: "configs-list",
+        summary: "List configs",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+    "/v3/configs/config/secrets": {
+      get: {
+        operationId: "secrets-list",
+        summary: "List secrets",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "config",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+  },
+};
+
+// Extended spec for filter testing - includes write methods and org-level endpoints
+export const filterTestOpenAPISpec = {
+  openapi: "3.0.0",
+  info: { title: "Doppler API", version: "1.0.0" },
+  servers: [{ url: "https://api.doppler.com" }],
+  paths: {
+    // Org-level endpoints (filtered by --project)
+    "/v3/workplace": {
+      get: {
+        operationId: "workplace-get",
+        summary: "Get workplace",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+      post: {
+        operationId: "workplace-update",
+        summary: "Update workplace",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+    "/v3/workplace/users": {
+      get: {
+        operationId: "workplace-users-list",
+        summary: "List workplace users",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+    "/v3/logs": {
+      get: {
+        operationId: "activity-logs-list",
+        summary: "List activity logs",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+    // Project-level endpoints (kept by --project)
+    "/v3/projects": {
+      get: {
+        operationId: "projects-list",
+        summary: "List projects",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+      post: {
+        operationId: "projects-create",
+        summary: "Create project",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+    "/v3/environments": {
+      get: {
+        operationId: "environments-list",
+        summary: "List environments",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+    // Config/secret endpoints (kept by --config)
+    "/v3/configs": {
+      get: {
+        operationId: "configs-list",
+        summary: "List configs",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "OK" } },
+      },
+      post: {
+        operationId: "configs-create",
+        summary: "Create config",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+    "/v3/configs/config/secrets": {
+      get: {
+        operationId: "secrets-list",
+        summary: "List secrets",
+        parameters: [
+          {
+            name: "project",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "config",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "OK" } },
+      },
+      post: {
+        operationId: "secrets-update",
+        summary: "Update secrets",
+        parameters: [],
+        responses: { "200": { description: "OK" } },
+      },
+    },
+  },
+};

--- a/tests/parser.integration.test.ts
+++ b/tests/parser.integration.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { OpenAPIParser } from "../src/parser.js";
+import type { OpenAPISpec } from "../src/types.js";
+
+describe("OpenAPIParser with real Doppler spec", () => {
+  let spec: OpenAPISpec;
+  let parser: OpenAPIParser;
+
+  beforeAll(async () => {
+    const response = await fetch("https://docs.doppler.com/openapi/core.json");
+    if (!response.ok) {
+      throw new Error(`Failed to fetch OpenAPI spec: ${response.status}`);
+    }
+    spec = await response.json();
+    parser = new OpenAPIParser(spec);
+  });
+
+  it("fetches and parses the spec successfully", () => {
+    expect(spec.openapi).toMatch(/^3\./);
+    expect(spec.paths).toBeDefined();
+  });
+
+  it("generates 50+ tools from the spec", () => {
+    const tools = parser.parseToTools();
+    expect(tools.length).toBeGreaterThan(50);
+  });
+
+  it("includes expected core Doppler endpoints", () => {
+    const tools = parser.parseToTools();
+    const toolNames = tools.map((t) => t.name);
+
+    expect(toolNames).toContain("workplace_get");
+    expect(toolNames).toContain("projects_list");
+    expect(toolNames).toContain("projects_create");
+    expect(toolNames).toContain("configs_list");
+    expect(toolNames).toContain("secrets_list");
+  });
+});

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,0 +1,597 @@
+import { describe, it, expect } from "vitest";
+import { OpenAPIParser } from "../src/parser.js";
+import type { OpenAPISpec } from "../src/types.js";
+
+const createMockSpec = (paths: OpenAPISpec["paths"] = {}): OpenAPISpec => ({
+  openapi: "3.0.0",
+  info: { title: "Test API", version: "1.0.0" },
+  servers: [{ url: "https://api.doppler.com" }],
+  paths,
+});
+
+describe("OpenAPIParser", () => {
+  describe("parseToTools", () => {
+    it("parses a simple GET endpoint into a tool", () => {
+      const spec = createMockSpec({
+        "/v3/workplace": {
+          get: {
+            operationId: "workplace-get",
+            summary: "Retrieve workplace info",
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe("workplace_get");
+      expect(tools[0].description).toBe("Retrieve workplace info");
+      expect(tools[0].method).toBe("GET");
+      expect(tools[0].endpoint).toBe("/v3/workplace");
+    });
+
+    it("sanitizes operation IDs by replacing hyphens with underscores", () => {
+      const spec = createMockSpec({
+        "/v3/projects": {
+          get: {
+            operationId: "projects-list",
+            summary: "List projects",
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].name).toBe("projects_list");
+    });
+
+    it("skips deprecated operations", () => {
+      const spec = createMockSpec({
+        "/v3/old-endpoint": {
+          get: {
+            operationId: "old-endpoint-get",
+            summary: "Old endpoint",
+            deprecated: true,
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+        "/v3/new-endpoint": {
+          get: {
+            operationId: "new-endpoint-get",
+            summary: "New endpoint",
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe("new_endpoint_get");
+    });
+
+    it("handles multiple HTTP methods on the same path", () => {
+      const spec = createMockSpec({
+        "/v3/projects": {
+          get: {
+            operationId: "projects-list",
+            summary: "List projects",
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+          post: {
+            operationId: "projects-create",
+            summary: "Create project",
+            parameters: [],
+            responses: { "201": { description: "Created" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools).toHaveLength(2);
+      expect(tools.map((t) => t.name).sort()).toEqual([
+        "projects_create",
+        "projects_list",
+      ]);
+      expect(tools.find((t) => t.name === "projects_list")?.method).toBe("GET");
+      expect(tools.find((t) => t.name === "projects_create")?.method).toBe(
+        "POST",
+      );
+    });
+
+    it("includes path parameters in tool definition", () => {
+      const spec = createMockSpec({
+        "/v3/projects/{project}": {
+          get: {
+            operationId: "projects-get",
+            summary: "Get project",
+            parameters: [
+              {
+                name: "project",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+                description: "The project slug",
+              },
+            ],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].parameters).toHaveLength(1);
+      expect(tools[0].parameters[0].name).toBe("project");
+      expect(tools[0].parameters[0].in).toBe("path");
+      expect(tools[0].parameters[0].required).toBe(true);
+    });
+
+    it("includes query parameters in tool definition", () => {
+      const spec = createMockSpec({
+        "/v3/configs": {
+          get: {
+            operationId: "configs-list",
+            summary: "List configs",
+            parameters: [
+              {
+                name: "project",
+                in: "query",
+                required: true,
+                schema: { type: "string" },
+              },
+              {
+                name: "environment",
+                in: "query",
+                required: false,
+                schema: { type: "string" },
+              },
+            ],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].parameters).toHaveLength(2);
+      expect(
+        tools[0].parameters.find((p) => p.name === "project")?.required,
+      ).toBe(true);
+      expect(
+        tools[0].parameters.find((p) => p.name === "environment")?.required,
+      ).toBe(false);
+    });
+
+    it("handles request body for POST operations", () => {
+      const spec = createMockSpec({
+        "/v3/projects": {
+          post: {
+            operationId: "projects-create",
+            summary: "Create project",
+            parameters: [],
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      name: { type: "string" },
+                      description: { type: "string" },
+                    },
+                    required: ["name"],
+                  },
+                },
+              },
+            },
+            responses: { "201": { description: "Created" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].requestBody).toBeDefined();
+      expect(
+        tools[0].requestBody?.content["application/json"].schema.properties,
+      ).toHaveProperty("name");
+    });
+
+    it("uses summary as description, falling back to description field", () => {
+      const spec = createMockSpec({
+        "/v3/endpoint1": {
+          get: {
+            operationId: "endpoint1-get",
+            summary: "Short summary",
+            description: "Longer description",
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+        "/v3/endpoint2": {
+          get: {
+            operationId: "endpoint2-get",
+            description: "Only description",
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools.find((t) => t.name === "endpoint1_get")?.description).toBe(
+        "Short summary",
+      );
+      expect(tools.find((t) => t.name === "endpoint2_get")?.description).toBe(
+        "Only description",
+      );
+    });
+  });
+
+  describe("hybrid tool naming", () => {
+    it("uses clean operationId when available", () => {
+      const spec = createMockSpec({
+        "/v3/secrets": {
+          get: {
+            operationId: "secrets-list",
+            summary: "List secrets",
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].name).toBe("secrets_list");
+    });
+
+    it("falls back to path-based naming for ugly operationIds with v3", () => {
+      const spec = createMockSpec({
+        "/v3/workplace/change_requests": {
+          get: {
+            operationId: "get_v3workplacechange_requests",
+            summary: "List change requests",
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].name).toBe("workplace_change_requests_list");
+    });
+
+    it("falls back to path-based naming for operationIds starting with HTTP method", () => {
+      const spec = createMockSpec({
+        "/v3/workplace/service_accounts": {
+          post: {
+            operationId: "post_v3workplace_service_accounts",
+            summary: "Create service account",
+            parameters: [],
+            responses: { "201": { description: "Created" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].name).toBe("workplace_service_accounts_create");
+    });
+
+    it("generates _get suffix for GET on path ending with param", () => {
+      const spec = createMockSpec({
+        "/v3/projects/{project}": {
+          get: {
+            operationId: "get_v3projects_project",
+            summary: "Get project",
+            parameters: [
+              {
+                name: "project",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].name).toBe("projects_get");
+    });
+
+    it("generates _list suffix for GET on collection path", () => {
+      const spec = createMockSpec({
+        "/v3/configs/config/secrets": {
+          get: {
+            operationId: "get_v3configs_secrets",
+            summary: "List secrets",
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].name).toBe("configs_config_secrets_list");
+    });
+
+    it("handles action paths like /clone and /lock", () => {
+      const spec = createMockSpec({
+        "/v3/configs/config/clone": {
+          post: {
+            operationId: "post_v3configs_clone",
+            summary: "Clone config",
+            parameters: [],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].name).toBe("configs_config_clone");
+    });
+
+    it("avoids conflicts for POST vs DELETE on action paths", () => {
+      const spec = createMockSpec({
+        "/v3/change_requests/{id}/review": {
+          post: {
+            operationId: "post_v3change_requests_review",
+            summary: "Create review",
+            parameters: [
+              {
+                name: "id",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: { "200": { description: "Success" } },
+          },
+          delete: {
+            operationId: "delete_v3change_requests_review",
+            summary: "Delete review",
+            parameters: [
+              {
+                name: "id",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+      const names = tools.map((t) => t.name);
+
+      expect(names).toContain("change_requests_review");
+      expect(names).toContain("change_requests_review_delete");
+      expect(names.length).toBe(2); // No duplicates
+    });
+
+    it("truncates long names to 64 characters", () => {
+      const spec = createMockSpec({
+        "/v3/workplace/service_accounts/service_account/{sa}/identities/identity/{id}":
+          {
+            get: {
+              operationId: "get_v3workplace_service_accounts_very_long_path",
+              summary: "Get identity",
+              parameters: [
+                {
+                  name: "sa",
+                  in: "path",
+                  required: true,
+                  schema: { type: "string" },
+                },
+                {
+                  name: "id",
+                  in: "path",
+                  required: true,
+                  schema: { type: "string" },
+                },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      expect(tools[0].name.length).toBeLessThanOrEqual(64);
+      expect(tools[0].name).not.toMatch(/_$/); // Shouldn't end with underscore
+    });
+  });
+
+  describe("input schema generation", () => {
+    it("creates required fields for required parameters", () => {
+      const spec = createMockSpec({
+        "/v3/configs": {
+          get: {
+            operationId: "configs-list",
+            summary: "List configs",
+            parameters: [
+              {
+                name: "project",
+                in: "query",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      const result = tools[0].inputSchema.safeParse({ project: "my-project" });
+      expect(result.success).toBe(true);
+
+      const failResult = tools[0].inputSchema.safeParse({});
+      expect(failResult.success).toBe(false);
+    });
+
+    it("allows optional fields to be omitted", () => {
+      const spec = createMockSpec({
+        "/v3/configs": {
+          get: {
+            operationId: "configs-list",
+            summary: "List configs",
+            parameters: [
+              {
+                name: "project",
+                in: "query",
+                required: true,
+                schema: { type: "string" },
+              },
+              {
+                name: "page",
+                in: "query",
+                required: false,
+                schema: { type: "integer" },
+              },
+            ],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      const result = tools[0].inputSchema.safeParse({ project: "my-project" });
+      expect(result.success).toBe(true);
+
+      const resultWithOptional = tools[0].inputSchema.safeParse({
+        project: "my-project",
+        page: 1,
+      });
+      expect(resultWithOptional.success).toBe(true);
+    });
+
+    it("preserves additional properties not defined in schema", () => {
+      const spec = createMockSpec({
+        "/v3/configs/config/secrets": {
+          post: {
+            operationId: "secrets-update",
+            summary: "Update secrets",
+            parameters: [],
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["project", "config"],
+                    properties: {
+                      project: { type: "string" },
+                      config: { type: "string" },
+                      secrets: {
+                        type: "object",
+                        properties: {
+                          EXAMPLE_KEY: { type: "string" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      const input = {
+        project: "my-app",
+        config: "dev",
+        secrets: {
+          MY_CUSTOM_SECRET: "secret-value",
+          ANOTHER_SECRET: "another-value",
+        },
+      };
+
+      const result = tools[0].inputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+
+      // Critical: extra properties must be preserved, not stripped
+      expect(result.data).toEqual(input);
+      expect(result.data.secrets.MY_CUSTOM_SECRET).toBe("secret-value");
+      expect(result.data.secrets.ANOTHER_SECRET).toBe("another-value");
+    });
+
+    it("preserves top-level additional properties", () => {
+      const spec = createMockSpec({
+        "/v3/endpoint": {
+          post: {
+            operationId: "endpoint-create",
+            summary: "Create something",
+            parameters: [],
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      name: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      });
+
+      const parser = new OpenAPIParser(spec);
+      const tools = parser.parseToTools();
+
+      const input = {
+        name: "test",
+        extraField: "should-be-preserved",
+      };
+
+      const result = tools[0].inputSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      expect(result.data.extraField).toBe("should-be-preserved");
+    });
+  });
+});

--- a/tests/scope.integration.test.ts
+++ b/tests/scope.integration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { detectImplicitScope } from "../src/scope.js";
+import { DopplerClient } from "../src/client.js";
+import { mockDopplerAPI } from "./helpers.js";
+
+const mockFetch = vi.fn();
+const originalFetch = global.fetch;
+const originalToken = process.env.DOPPLER_TOKEN;
+
+beforeEach(() => {
+  process.env.DOPPLER_TOKEN = "dp.test.fake_token_for_testing";
+  global.fetch = mockFetch;
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  if (originalToken) {
+    process.env.DOPPLER_TOKEN = originalToken;
+  } else {
+    delete process.env.DOPPLER_TOKEN;
+  }
+});
+
+describe("detectImplicitScope with DopplerClient", () => {
+  it("detects both project and config when exactly one of each", async () => {
+    mockDopplerAPI(mockFetch, {
+      projects: ["my-app"],
+      configs: { "my-app": ["production"] },
+    });
+
+    const scope = await detectImplicitScope(new DopplerClient());
+
+    expect(scope.project).toBe("my-app");
+    expect(scope.config).toBe("production");
+  });
+
+  it("detects only project when multiple configs exist", async () => {
+    mockDopplerAPI(mockFetch, {
+      projects: ["my-app"],
+      configs: { "my-app": ["dev", "stg", "prd"] },
+    });
+
+    const scope = await detectImplicitScope(new DopplerClient());
+
+    expect(scope.project).toBe("my-app");
+    expect(scope.config).toBeUndefined();
+  });
+
+  it("detects nothing when multiple projects exist", async () => {
+    mockDopplerAPI(mockFetch, {
+      projects: ["app-one", "app-two", "app-three"],
+    });
+
+    const scope = await detectImplicitScope(new DopplerClient());
+
+    expect(scope.project).toBeUndefined();
+    expect(scope.config).toBeUndefined();
+  });
+});

--- a/tests/scope.test.ts
+++ b/tests/scope.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  detectImplicitScope,
+  mergeScope,
+  validateScope,
+  type ScopeClient,
+  type ScopeOptions,
+} from "../src/scope.js";
+
+function mockClient(
+  projects: string[],
+  configs: Record<string, string[]> = {},
+): ScopeClient {
+  return {
+    listProjects: vi.fn().mockResolvedValue(projects.map((slug) => ({ slug }))),
+    listConfigs: vi
+      .fn()
+      .mockImplementation(async (project: string) =>
+        (configs[project] ?? []).map((name) => ({ name, slug: name })),
+      ),
+  };
+}
+
+describe("detectImplicitScope", () => {
+  it("returns project + config when exactly one of each", async () => {
+    const client = mockClient(["my-app"], { "my-app": ["production"] });
+
+    const scope = await detectImplicitScope(client);
+
+    expect(scope.project).toBe("my-app");
+    expect(scope.config).toBe("production");
+    expect(client.listProjects).toHaveBeenCalledTimes(1);
+    expect(client.listConfigs).toHaveBeenCalledWith("my-app");
+  });
+
+  it("returns only project when multiple configs exist", async () => {
+    const client = mockClient(["my-app"], { "my-app": ["dev", "stg", "prd"] });
+
+    const scope = await detectImplicitScope(client);
+
+    expect(scope.project).toBe("my-app");
+    expect(scope.config).toBeUndefined();
+  });
+
+  it("returns empty when multiple projects exist", async () => {
+    const client = mockClient(["app-one", "app-two"]);
+
+    const scope = await detectImplicitScope(client);
+
+    expect(scope.project).toBeUndefined();
+    expect(scope.config).toBeUndefined();
+    expect(client.listConfigs).not.toHaveBeenCalled();
+  });
+
+  it("returns empty when no projects exist", async () => {
+    const client = mockClient([]);
+
+    const scope = await detectImplicitScope(client);
+
+    expect(scope.project).toBeUndefined();
+    expect(scope.config).toBeUndefined();
+  });
+
+  it("returns only project when no configs exist", async () => {
+    const client = mockClient(["my-app"], { "my-app": [] });
+
+    const scope = await detectImplicitScope(client);
+
+    expect(scope.project).toBe("my-app");
+    expect(scope.config).toBeUndefined();
+  });
+});
+
+describe("mergeScope", () => {
+  it("CLI args take precedence", () => {
+    const detected = { project: "detected-project", config: "detected-config" };
+    const cliArgs = { project: "cli-project", config: "cli-config" };
+
+    const result = mergeScope(detected, cliArgs);
+
+    expect(result.project).toBe("cli-project");
+    expect(result.config).toBe("cli-config");
+  });
+
+  it("uses detected values when CLI args undefined", () => {
+    const detected = { project: "detected-project", config: "detected-config" };
+
+    const result = mergeScope(detected, {
+      project: undefined,
+      config: undefined,
+    });
+
+    expect(result.project).toBe("detected-project");
+    expect(result.config).toBe("detected-config");
+  });
+
+  it("clears config when CLI provides different project", () => {
+    const detected = { project: "detected-project", config: "detected-config" };
+
+    const result = mergeScope(detected, {
+      project: "different-project",
+      config: undefined,
+    });
+
+    expect(result.project).toBe("different-project");
+    expect(result.config).toBeUndefined();
+  });
+
+  it("keeps config when CLI provides same project", () => {
+    const detected = { project: "my-project", config: "detected-config" };
+
+    const result = mergeScope(detected, {
+      project: "my-project",
+      config: undefined,
+    });
+
+    expect(result.project).toBe("my-project");
+    expect(result.config).toBe("detected-config");
+  });
+
+  it("allows CLI config to override detected config", () => {
+    const detected = { project: "my-project", config: "detected-config" };
+
+    const result = mergeScope(detected, {
+      project: undefined,
+      config: "cli-config",
+    });
+
+    expect(result.project).toBe("my-project");
+    expect(result.config).toBe("cli-config");
+  });
+});
+
+describe("validateScope", () => {
+  it("throws when --config without effective project", () => {
+    expect(() =>
+      validateScope(
+        { project: undefined, config: undefined },
+        { project: undefined, config: "production" },
+      ),
+    ).toThrow(/--config requires --project/);
+  });
+
+  it("error mentions multiple projects", () => {
+    expect(() =>
+      validateScope(
+        { project: undefined, config: undefined },
+        { project: undefined, config: "production" },
+      ),
+    ).toThrow(/multiple projects/i);
+  });
+
+  it("allows --config with --project", () => {
+    expect(() =>
+      validateScope(
+        { project: undefined, config: undefined },
+        { project: "my-project", config: "production" },
+      ),
+    ).not.toThrow();
+  });
+
+  it("allows --config with detected project", () => {
+    expect(() =>
+      validateScope(
+        { project: "detected-project", config: undefined },
+        { project: undefined, config: "production" },
+      ),
+    ).not.toThrow();
+  });
+
+  it("allows no --config", () => {
+    expect(() =>
+      validateScope(
+        { project: undefined, config: undefined },
+        { project: undefined, config: undefined },
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("ScopeOptions type", () => {
+  it("can be constructed with all fields", () => {
+    const options: ScopeOptions = {
+      project: "my-project",
+      projectSource: "cli",
+      config: "production",
+      configSource: "token",
+    };
+
+    expect(options.project).toBe("my-project");
+    expect(options.projectSource).toBe("cli");
+    expect(options.config).toBe("production");
+    expect(options.configSource).toBe("token");
+  });
+
+  it("allows partial construction", () => {
+    const options: ScopeOptions = {
+      project: "my-project",
+    };
+
+    expect(options.project).toBe("my-project");
+    expect(options.config).toBeUndefined();
+  });
+});

--- a/tests/startup-warnings.test.ts
+++ b/tests/startup-warnings.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+import { isProductionConfig } from "../src/access-warnings.js";
+
+interface StartupContext {
+  tokenType: string;
+  readOnly: boolean;
+  project?: string;
+  config?: string;
+}
+
+// Mirror of warning generation logic from index.ts
+function generateWarnings(ctx: StartupContext): string[] {
+  const warnings: string[] = [];
+
+  if (ctx.tokenType === "unknown") {
+    warnings.push("CRITICAL: unknown token");
+  }
+
+  if (!ctx.readOnly && ctx.config && isProductionConfig(ctx.config)) {
+    warnings.push(`CRITICAL: production config "${ctx.config}"`);
+  }
+
+  if (!ctx.readOnly) {
+    warnings.push("WARNING: write access");
+  }
+
+  if (!ctx.project) {
+    warnings.push("WARNING: full workspace access");
+  }
+
+  return warnings;
+}
+
+describe("isProductionConfig", () => {
+  describe("exact matches", () => {
+    it.each(["prod", "prd", "production", "live"])(
+      "matches %s (case insensitive)",
+      (config) => {
+        expect(isProductionConfig(config)).toBe(true);
+        expect(isProductionConfig(config.toUpperCase())).toBe(true);
+        expect(
+          isProductionConfig(config.charAt(0).toUpperCase() + config.slice(1)),
+        ).toBe(true);
+      },
+    );
+  });
+
+  describe("suffix patterns", () => {
+    it.each([
+      "app_prod",
+      "app_prd",
+      "app_production",
+      "app-prod",
+      "app-prd",
+      "app-production",
+      "my-service_prod",
+      "API_PROD",
+    ])("matches %s", (config) => {
+      expect(isProductionConfig(config)).toBe(true);
+    });
+  });
+
+  describe("non-production configs", () => {
+    it.each([
+      "dev",
+      "development",
+      "staging",
+      "stg",
+      "test",
+      "qa",
+      "sandbox",
+      "local",
+      "prod_backup", // prod is prefix, not suffix
+      "production_old",
+      "my-product", // contains 'prod' but not as suffix
+      "reproduce", // contains 'prod' substring
+    ])("does not match %s", (config) => {
+      expect(isProductionConfig(config)).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty string", () => {
+      expect(isProductionConfig("")).toBe(false);
+    });
+
+    it("handles single characters", () => {
+      expect(isProductionConfig("p")).toBe(false);
+    });
+  });
+});
+
+describe("startup warnings generation", () => {
+  describe("unknown token type", () => {
+    it("emits critical warning for unknown token", () => {
+      const warnings = generateWarnings({
+        tokenType: "unknown",
+        readOnly: true,
+        project: "my-app",
+      });
+
+      expect(warnings).toContainEqual(expect.stringContaining("CRITICAL"));
+      expect(warnings).toContainEqual(expect.stringContaining("unknown token"));
+    });
+
+    it("does not emit for known token types", () => {
+      for (const tokenType of ["service_account", "personal", "cli"]) {
+        const warnings = generateWarnings({
+          tokenType,
+          readOnly: true,
+          project: "my-app",
+        });
+
+        expect(warnings.some((w) => w.includes("unknown token"))).toBe(false);
+      }
+    });
+  });
+
+  describe("production config with write access", () => {
+    it("emits critical warning for production + write", () => {
+      const warnings = generateWarnings({
+        tokenType: "service_account",
+        readOnly: false,
+        project: "my-app",
+        config: "production",
+      });
+
+      expect(warnings).toContainEqual(expect.stringContaining("CRITICAL"));
+      expect(warnings).toContainEqual(
+        expect.stringContaining("production config"),
+      );
+    });
+
+    it("does not emit for production + read-only", () => {
+      const warnings = generateWarnings({
+        tokenType: "service_account",
+        readOnly: true,
+        project: "my-app",
+        config: "production",
+      });
+
+      expect(warnings.some((w) => w.includes("production config"))).toBe(false);
+    });
+
+    it("does not emit for non-production configs", () => {
+      const warnings = generateWarnings({
+        tokenType: "service_account",
+        readOnly: false,
+        project: "my-app",
+        config: "development",
+      });
+
+      expect(warnings.some((w) => w.includes("production config"))).toBe(false);
+    });
+  });
+
+  describe("write access warning", () => {
+    it("emits warning when write access is enabled", () => {
+      const warnings = generateWarnings({
+        tokenType: "service_account",
+        readOnly: false,
+        project: "my-app",
+      });
+
+      expect(warnings).toContainEqual(expect.stringContaining("write access"));
+    });
+
+    it("does not emit when read-only", () => {
+      const warnings = generateWarnings({
+        tokenType: "service_account",
+        readOnly: true,
+        project: "my-app",
+      });
+
+      expect(warnings.some((w) => w.includes("write access"))).toBe(false);
+    });
+  });
+
+  describe("workspace scope warning", () => {
+    it("emits warning when no project scope", () => {
+      const warnings = generateWarnings({
+        tokenType: "service_account",
+        readOnly: true,
+      });
+
+      expect(warnings).toContainEqual(
+        expect.stringContaining("full workspace access"),
+      );
+    });
+
+    it("does not emit when project is scoped", () => {
+      const warnings = generateWarnings({
+        tokenType: "service_account",
+        readOnly: true,
+        project: "my-app",
+      });
+
+      expect(warnings.some((w) => w.includes("full workspace"))).toBe(false);
+    });
+  });
+
+  describe("combined scenarios", () => {
+    it("safest config: read-only + project-scoped + known token", () => {
+      const warnings = generateWarnings({
+        tokenType: "service_account",
+        readOnly: true,
+        project: "my-app",
+        config: "development",
+      });
+
+      // Should have no warnings at all
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("riskiest config: write + no scope + unknown token + production", () => {
+      const warnings = generateWarnings({
+        tokenType: "unknown",
+        readOnly: false,
+        config: "production",
+      });
+
+      // Should have all warnings
+      expect(warnings.length).toBeGreaterThanOrEqual(3);
+      expect(warnings.some((w) => w.includes("CRITICAL"))).toBe(true);
+      expect(warnings.some((w) => w.includes("write access"))).toBe(true);
+      expect(warnings.some((w) => w.includes("full workspace"))).toBe(true);
+    });
+  });
+});

--- a/tests/startup.test.ts
+++ b/tests/startup.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mockDopplerAPI, minimalOpenAPISpec } from "./helpers.js";
+
+const mockFetch = vi.fn();
+const originalFetch = global.fetch;
+const originalEnv = { ...process.env };
+
+describe("MCP server startup", () => {
+  let consoleOutput: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+
+  beforeEach(() => {
+    consoleOutput = [];
+    console.log = (...args) => consoleOutput.push(args.join(" "));
+    console.error = (...args) => consoleOutput.push(args.join(" "));
+
+    process.env = { ...originalEnv };
+    process.env.DOPPLER_TOKEN = "dp.st.test_token";
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+
+    vi.resetModules();
+
+    vi.doMock("fs", () => ({
+      readFileSync: () => JSON.stringify(minimalOpenAPISpec),
+    }));
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  it("auto-detects and logs scope from config-scoped token", async () => {
+    mockDopplerAPI(mockFetch, {
+      projects: ["my-app"],
+      configs: { "my-app": ["production"] },
+    });
+
+    const { createDopplerMCPServer } = await import("../src/index.js");
+    await createDopplerMCPServer({ verbose: true });
+
+    const output = consoleOutput.join("\n");
+    expect(output).toContain("my-app");
+    expect(output).toContain("production");
+    expect(output).toMatch(/auto[- ]?detect|implicit|detected/i);
+  });
+
+  it("auto-detects project only when multiple configs exist", async () => {
+    mockDopplerAPI(mockFetch, {
+      projects: ["my-app"],
+      configs: { "my-app": ["dev", "staging", "production"] },
+    });
+
+    const { createDopplerMCPServer } = await import("../src/index.js");
+    await createDopplerMCPServer({ verbose: true });
+
+    const output = consoleOutput.join("\n");
+    expect(output).toContain("my-app");
+    expect(output).toMatch(/auto[- ]?detect|implicit|detected/i);
+  });
+
+  it("CLI args override auto-detected scope", async () => {
+    mockDopplerAPI(mockFetch, {
+      projects: ["my-app"],
+      configs: { "my-app": ["production"] },
+    });
+
+    const { createDopplerMCPServer } = await import("../src/index.js");
+    await createDopplerMCPServer({
+      verbose: true,
+      project: "other-project",
+      config: "dev",
+    });
+
+    const output = consoleOutput.join("\n");
+    expect(output).toContain("other-project");
+    expect(output).toContain("dev");
+  });
+
+  it("errors when --config provided without effective project", async () => {
+    mockDopplerAPI(mockFetch, {
+      projects: ["app-one", "app-two"],
+    });
+
+    const { createDopplerMCPServer } = await import("../src/index.js");
+
+    try {
+      await createDopplerMCPServer({ config: "production" });
+    } catch {
+      // process.exit throws in test environment
+    }
+
+    const output = consoleOutput.join("\n");
+    expect(output).toMatch(/--config requires --project/);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+    },
+  },
+});


### PR DESCRIPTION
### Local Testing
```
  # Install dependencies
  pnpm install

  # Build (fetches OpenAPI spec and compiles)
  pnpm build

  # Run tests
  pnpm test
```

  Add to your Claude Desktop config (~/Library/Application Support/Claude/claude_desktop_config.json):
```
  {
    "mcpServers": {
      "doppler": {
        "command": "node",
        "args": ["/path/to/doppler-mcp/dist/index.js", "--verbose"],
        "env": {
          "DOPPLER_TOKEN": "dp.st.your_token"
        }
      }
    }
  }
```

Restart Claude Desktop and try: `Test the Doppler MCP integration: list my projects, pick one and list its configs, then create a test secret called MCP_TEST with value "hello", read it back to verify, then delete it.`

> [!NOTE]
> I tested this with Claude Desktop only. Has not yet been tested with ChatGPT or other MCP clients.

Closes ENG-9058