### PR TITLE
Add NPM publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Publish Package
 
 on:
-#   push:
-#     tags:
-#       - 'v*'
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   id-token: write # Required for OIDC publishing
@@ -18,3 +18,13 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+      - name: Set version from tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          npm pkg set version="$VERSION"
+          npm pkg set private=false --json
+      - run: npm ci
+      - run: npm run build
+      - name: Verify startup
+        run: node dist/index.js --help
+      - run: npm publish --provenance

--- a/README.md
+++ b/README.md
@@ -235,3 +235,9 @@ pnpm run build
 # Run locally
 DOPPLER_TOKEN=dp.xxx pnpm start
 ```
+
+## Branch and Release Flow
+
+New work should branch from main and target main in PRs.
+
+To release, push a tag in the format `vX.X.X` following semantic versioning. This triggers the publish workflow which builds and publishes to NPM.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "type": "module",
   "bin": {
-    "doppler-mcp": "./bin/doppler-mcp"
+    "doppler-mcp": "bin/doppler-mcp"
   },
   "scripts": {
     "fetch-openapi": "curl -s https://docs.doppler.com/openapi/core.json -o doppler-openapi.json",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "dev": "tsx --esm src/index.ts",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "test:watch": "vitest",
-    "prepublishOnly": "npm run build"
+    "test:watch": "vitest"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
This PR updates the existing `publish` GitHub Action to publish the package to NPM when a version tag is pushed.

Closes ENG-9060