### PR TITLE
Add device code authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,28 @@ MCP (Model Context Protocol) server that provides AI assistants with access to t
 
 ## Quick Start
 
-Add to your MCP client configuration (e.g., Claude Desktop):
+**1. Authenticate:**
+
+```bash
+npx @dopplerhq/mcp-server login
+```
+
+**2. Add to your MCP client configuration (e.g., Claude Desktop):**
+
+```json
+{
+  "mcpServers": {
+    "doppler": {
+      "command": "npx",
+      "args": ["-y", "@dopplerhq/mcp-server"]
+    }
+  }
+}
+```
+
+### With Service Token
+
+Alternatively, use a service token instead of logging in:
 
 ```json
 {
@@ -20,60 +41,16 @@ Add to your MCP client configuration (e.g., Claude Desktop):
 }
 ```
 
-See [Service Tokens](https://docs.doppler.com/docs/service-tokens) to create a token.
+See [Service Tokens](https://docs.doppler.com/docs/service-tokens) to create a config-scoped token.
 
-### Alternative: CLI Authentication (No Token in Config)
+## Commands
 
-If you have the [Doppler CLI](https://docs.doppler.com/docs/cli) installed, you can use your CLI session instead of a service token. This keeps credentials out of your config file entirely.
-
-**Prerequisites:**
-
-1. Install the Doppler CLI
-2. Run `doppler login` (creates a global/root session stored in your OS keychain)
-3. Create a Doppler project to store your `DOPPLER_TOKEN` for the MCP server
-
-**Configuration:**
-
-```json
-{
-  "mcpServers": {
-    "doppler": {
-      "command": "doppler",
-      "args": [
-        "run",
-        "--project",
-        "mcp-server-tokens",
-        "--config",
-        "dev",
-        "--",
-        "npx",
-        "-y",
-        "@dopplerhq/mcp-server",
-        "--project",
-        "my-app",
-        "--read-only"
-      ]
-    }
-  }
-}
+```
+login              Authenticate with Doppler (interactive)
+logout             Clear cached auth credentials
 ```
 
-**How it works:**
-
-- `doppler run --project mcp-server-tokens --config dev` fetches secrets (including `DOPPLER_TOKEN`) from the specified Doppler project and injects them as environment variables
-- The MCP server receives `DOPPLER_TOKEN` and uses it to access the Doppler API
-- `--project my-app --read-only` on the MCP server scopes what the LLM can access
-
-**Two levels of scoping:**
-
-| Level                            | Controls                              | Example                                                    |
-| -------------------------------- | ------------------------------------- | ---------------------------------------------------------- |
-| `doppler run --project/--config` | Which token the MCP server uses       | `mcp-server-tokens/dev` contains `DOPPLER_TOKEN=dp.st.xxx` |
-| MCP server `--project/--config`  | What the LLM can access via the token | Restrict to `my-app/production`                            |
-
-This pattern is ideal for local development where you don't want any tokens in config files.
-
-## CLI Options
+## Options
 
 ```
 --read-only        Only expose read operations (GET endpoints)
@@ -92,8 +69,7 @@ This pattern is ideal for local development where you don't want any tokens in c
   "mcpServers": {
     "doppler": {
       "command": "npx",
-      "args": ["-y", "@dopplerhq/mcp-server", "--read-only"],
-      "env": { "DOPPLER_TOKEN": "dp.pt.xxx" }
+      "args": ["-y", "@dopplerhq/mcp-server", "--read-only"]
     }
   }
 }
@@ -106,8 +82,7 @@ This pattern is ideal for local development where you don't want any tokens in c
   "mcpServers": {
     "doppler": {
       "command": "npx",
-      "args": ["-y", "@dopplerhq/mcp-server", "--project", "my-app"],
-      "env": { "DOPPLER_TOKEN": "dp.pt.xxx" }
+      "args": ["-y", "@dopplerhq/mcp-server", "--project", "my-app"]
     }
   }
 }
@@ -127,8 +102,7 @@ This pattern is ideal for local development where you don't want any tokens in c
         "my-app",
         "--config",
         "production"
-      ],
-      "env": { "DOPPLER_TOKEN": "dp.pt.xxx" }
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.5.0",
+    "@napi-rs/keyring": "^1.1.6",
     "fastmcp": "^3.10.0",
     "zod": "^3.22.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^0.5.0
         version: 0.5.0
+      '@napi-rs/keyring':
+        specifier: ^1.1.6
+        version: 1.2.0
       fastmcp:
         specifier: ^3.10.0
         version: 3.26.8(hono@4.11.3)
@@ -354,6 +357,82 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    resolution: {integrity: sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.2.0':
+    resolution: {integrity: sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==}
+    engines: {node: '>= 10'}
 
   '@rollup/rollup-android-arm-eabi@4.55.1':
     resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
@@ -1442,6 +1521,57 @@ snapshots:
       - hono
       - supports-color
 
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring@1.2.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.2.0
+      '@napi-rs/keyring-darwin-x64': 1.2.0
+      '@napi-rs/keyring-freebsd-x64': 1.2.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.2.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.2.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-musl': 1.2.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.2.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.2.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.2.0
+
   '@rollup/rollup-android-arm-eabi@4.55.1':
     optional: true
 
@@ -1833,7 +1963,7 @@ snapshots:
       strict-event-emitter-types: 2.0.0
       undici: 7.18.2
       uri-templates: 0.2.0
-      xsschema: 0.4.0-beta.5(zod-to-json-schema@3.25.1(zod@4.3.5))(zod@4.3.5)
+      xsschema: 0.4.0-beta.5(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@4.3.5)
       yargs: 18.0.0
       zod: 4.3.5
       zod-to-json-schema: 3.25.1(zod@4.3.5)
@@ -2313,7 +2443,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  xsschema@0.4.0-beta.5(zod-to-json-schema@3.25.1(zod@4.3.5))(zod@4.3.5):
+  xsschema@0.4.0-beta.5(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@4.3.5):
     optionalDependencies:
       zod: 4.3.5
       zod-to-json-schema: 3.25.1(zod@4.3.5)

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,8 +14,8 @@ export class DopplerClient {
   private authManager: AuthManager;
   private baseUrl: string;
 
-  constructor() {
-    this.authManager = new AuthManager();
+  constructor(authManager: AuthManager) {
+    this.authManager = authManager;
     this.baseUrl = this.authManager.getBaseUrl();
   }
 

--- a/src/device-auth.ts
+++ b/src/device-auth.ts
@@ -1,0 +1,182 @@
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function getVersion(): string {
+  const packagePath = path.join(__dirname, "..", "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf-8"));
+  return `mcp-v${packageJson.version}`;
+}
+
+const CLI_VERSION = getVersion();
+
+export interface AuthCodeResponse {
+  code: string;
+  pollingCode: string;
+  authUrl: string;
+}
+
+export type PollResult =
+  | { pending: true }
+  | {
+      pending: false;
+      token: string;
+      name: string;
+      dashboardUrl: string;
+    };
+
+export async function generateAuthCode(
+  baseUrl: string = "https://api.doppler.com",
+): Promise<AuthCodeResponse> {
+  const hostname = os.hostname();
+  const osType = process.platform;
+  const arch = process.arch;
+
+  const params = new URLSearchParams({
+    hostname,
+    version: CLI_VERSION,
+    os: osType,
+    arch,
+    client_type: "mcp",
+  });
+
+  const url = `${baseUrl}/v3/auth/cli/generate/2?${params.toString()}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": `doppler-mcp-server/${CLI_VERSION}`,
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `Failed to generate auth code: ${response.status} ${response.statusText} - ${text}`,
+    );
+  }
+
+  const data = await response.json();
+
+  return {
+    code: data.code,
+    pollingCode: data.polling_code,
+    authUrl: data.auth_url,
+  };
+}
+
+export async function pollForToken(
+  pollingCode: string,
+  baseUrl: string = "https://api.doppler.com",
+): Promise<PollResult> {
+  const url = `${baseUrl}/v3/auth/cli/authorize`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": `doppler-mcp-server/${CLI_VERSION}`,
+    },
+    body: JSON.stringify({ code: pollingCode }),
+  });
+
+  if (response.status === 409) {
+    return { pending: true };
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `Failed to poll for token: ${response.status} ${response.statusText} - ${text}`,
+    );
+  }
+
+  const data = await response.json();
+
+  if (data.error) {
+    throw new Error(`Authentication failed: ${data.error}`);
+  }
+
+  return {
+    pending: false,
+    token: data.token,
+    name: data.name,
+    dashboardUrl: data.dashboard_url,
+  };
+}
+
+export class DeviceAuthState {
+  public readonly code: string;
+  public readonly pollingCode: string;
+  public readonly authUrl: string;
+  public readonly baseUrl: string;
+  public readonly startedAt: Date;
+
+  private _isAuthenticated: boolean = false;
+  private _pollingInterval?: ReturnType<typeof setInterval>;
+
+  constructor(authCodeResponse: AuthCodeResponse, baseUrl: string = "https://api.doppler.com") {
+    this.code = authCodeResponse.code;
+    this.pollingCode = authCodeResponse.pollingCode;
+    this.authUrl = authCodeResponse.authUrl;
+    this.baseUrl = baseUrl;
+    this.startedAt = new Date();
+  }
+
+  private isTimedOut(): boolean {
+    const timeoutMs = 5 * 60 * 1000;
+    return Date.now() - this.startedAt.getTime() > timeoutMs;
+  }
+
+  private complete(): void {
+    this._isAuthenticated = true;
+    this.stopPolling();
+  }
+
+  startPolling(onAuthenticated: (result: { token: string; name: string }) => void): void {
+    if (this._pollingInterval) {
+      return;
+    }
+
+    const poll = async () => {
+      if (this._isAuthenticated) {
+        this.stopPolling();
+        return;
+      }
+
+      if (this.isTimedOut()) {
+        this.stopPolling();
+        console.error("Authentication timed out after 5 minutes.");
+        return;
+      }
+
+      try {
+        const result = await pollForToken(this.pollingCode, this.baseUrl);
+        if (!result.pending) {
+          this.complete();
+          onAuthenticated({ token: result.token, name: result.name });
+        }
+      } catch (error) {
+        console.error(
+          "Polling error:",
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    };
+
+    poll();
+    this._pollingInterval = setInterval(poll, 2000);
+  }
+
+  stopPolling(): void {
+    if (this._pollingInterval) {
+      clearInterval(this._pollingInterval);
+      this._pollingInterval = undefined;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,11 @@ import {
   createConfirmAccessTool,
   type AccessContext,
 } from "./access-warnings.js";
+import { TokenCache } from "./token-cache.js";
+import { generateAuthCode, DeviceAuthState } from "./device-auth.js";
 
 interface CLIOptions {
+  command?: "login" | "logout";
   readOnly?: boolean;
   project?: string;
   config?: string;
@@ -59,6 +62,10 @@ function parseCLIArgs(): CLIOptions {
     const arg = args[i];
 
     switch (arg) {
+      case "login":
+      case "logout":
+        options.command = arg;
+        break;
       case "--read-only":
         options.readOnly = true;
         break;
@@ -86,7 +93,11 @@ function showHelp() {
   console.log(`
 Doppler MCP Server
 
-Usage: npx @dopplerhq/mcp-server [options]
+Usage: npx @dopplerhq/mcp-server [command] [options]
+
+Commands:
+  login              Authenticate with Doppler (interactive)
+  logout             Clear cached auth credentials
 
 Options:
   --read-only        Enable read-only mode (only GET operations)
@@ -96,41 +107,191 @@ Options:
   --help, -h         Show this help message
 
 Environment Variables:
-  DOPPLER_TOKEN        Your Doppler API token (required)
+  DOPPLER_TOKEN        Your Doppler API token (optional if logged in)
   DOPPLER_BASE_URL     Base URL for Doppler API (optional)
 
-Scope Detection:
-  The server auto-detects scope from your token's access:
-  - Single project access → project set automatically
-  - Single config access  → config set automatically
-  CLI flags override auto-detected values.
-
 Examples:
-  # Basic usage (scope auto-detected from token)
+  # First-time setup: authenticate with Doppler
+  npx @dopplerhq/mcp-server login
+
+  # Run the server (uses cached credentials)
+  npx @dopplerhq/mcp-server
+
+  # With explicit token (no login required)
   DOPPLER_TOKEN=dp.st.xxx npx @dopplerhq/mcp-server
 
   # Read-only mode
-  DOPPLER_TOKEN=dp.xxx npx @dopplerhq/mcp-server --read-only
+  npx @dopplerhq/mcp-server --read-only
 
-  # Override auto-detected project
-  DOPPLER_TOKEN=dp.xxx npx @dopplerhq/mcp-server --project my-app
+  # Clear cached credentials
+  npx @dopplerhq/mcp-server logout
 `);
+}
+
+type AuthenticatedServerResult =
+  | { success: true; server: FastMCP }
+  | { success: false; reason: "invalid_token" };
+
+function showAuthRequiredError(): never {
+  console.error(
+    "Not authenticated. Run 'npx @dopplerhq/mcp-server login' first, or set DOPPLER_TOKEN environment variable.",
+  );
+  process.exit(1);
+}
+
+async function startAuthenticatedServer(
+  options: CLIOptions,
+  openApiSpec: OpenAPISpec,
+  token: string,
+): Promise<AuthenticatedServerResult> {
+  const authManager = new AuthManager(token);
+  const client = new DopplerClient(authManager);
+
+  log("Testing Doppler API connection...");
+  const connectionTest = await client.testConnection();
+  if (!connectionTest.success) {
+    return { success: false, reason: "invalid_token" };
+  }
+  log("✓ Successfully connected to Doppler API");
+
+  const tokenType = detectTokenType(token);
+
+  // Only auto-detect scope for service tokens (dp.st.*) which are genuinely
+  // scoped by Doppler. For other token types (service accounts, personal, etc.),
+  // seeing one project just means "workspace currently has one project" -
+  // creating another would change the scope unexpectedly.
+  const detectedScope =
+    tokenType === "service_token"
+      ? await detectImplicitScope(client)
+      : { project: undefined, config: undefined };
+
+  const cliScope = { project: options.project, config: options.config };
+  validateScope(detectedScope, cliScope);
+
+  const effectiveScope = mergeScope(detectedScope, cliScope);
+
+  if (detectedScope.project || detectedScope.config) {
+    const parts = [];
+    if (detectedScope.project) parts.push(`project: ${detectedScope.project}`);
+    if (detectedScope.config) parts.push(`config: ${detectedScope.config}`);
+    log(`✓ Auto-detected scope: ${parts.join(", ")}`);
+  }
+
+  const scopeOptions = {
+    project: effectiveScope.project,
+    projectSource: options.project
+      ? "cli"
+      : detectedScope.project
+        ? "token"
+        : undefined,
+    config: effectiveScope.config,
+    configSource: options.config
+      ? "cli"
+      : detectedScope.config
+        ? "token"
+        : undefined,
+  } as const;
+
+  const parser = new OpenAPIParser(openApiSpec);
+  const generator = new ToolGenerator(client, scopeOptions);
+
+  log("Parsing OpenAPI specification...");
+  let dopplerTools = parser.parseToTools();
+
+  if (options.readOnly) {
+    dopplerTools = dopplerTools.filter((tool) => tool.method === "GET");
+    log(`✓ Filtered to ${dopplerTools.length} read-only endpoints`);
+  } else {
+    log(`✓ Parsed ${dopplerTools.length} API endpoints`);
+  }
+
+  if (effectiveScope.project) {
+    const beforeCount = dopplerTools.length;
+    dopplerTools = dopplerTools.filter(
+      (tool) =>
+        !ORG_LEVEL_ENDPOINT_PREFIXES.some((prefix) =>
+          tool.endpoint.startsWith(prefix),
+        ),
+    );
+    log(
+      `✓ Filtered out org-level tools: ${beforeCount} → ${dopplerTools.length} endpoints`,
+    );
+  }
+
+  if (effectiveScope.config) {
+    dopplerTools = dopplerTools.filter(
+      (tool) =>
+        tool.endpoint.includes("/configs/") ||
+        tool.name.includes("config") ||
+        tool.endpoint.includes("/secrets/") ||
+        tool.name.includes("secret"),
+    );
+    log(
+      `✓ Filtered for config-related tools: ${dopplerTools.length} endpoints`,
+    );
+  }
+
+  log("Generating MCP tools...");
+  const mcpTools = generator.generateTools(dopplerTools);
+  log(`✓ Generated ${mcpTools.length} MCP tools`);
+
+  const accessContext: AccessContext = {
+    tokenType,
+    readOnly: options.readOnly ?? false,
+    project: effectiveScope.project,
+    config: effectiveScope.config,
+  };
+  emitStartupMessages(accessContext);
+
+  const serverName = options.readOnly ? "doppler-api-readonly" : "doppler-api";
+  const server = new FastMCP({
+    name: serverName,
+    version: "1.0.0",
+  });
+
+  const confirmAccessTool = createConfirmAccessTool(accessContext);
+  if (confirmAccessTool) {
+    server.addTool(confirmAccessTool);
+  }
+
+  for (const tool of mcpTools) {
+    server.addTool(tool);
+  }
+
+  server.start({ transportType: "stdio" });
+
+  const modeText = options.readOnly ? " (Read-Only Mode)" : "";
+  log(`Doppler MCP Server started successfully!${modeText}`);
+  log(`Available tools: ${mcpTools.length}`);
+  log(`Base URL: ${client.getBaseUrl()}`);
+
+  if (options.readOnly) {
+    log("Read-only mode: Only GET operations are available");
+  }
+  if (effectiveScope.project) {
+    log(`Project: ${effectiveScope.project}`);
+  }
+  if (effectiveScope.config) {
+    log(`Config: ${effectiveScope.config}`);
+  }
+
+  const exampleTools = dopplerTools.slice(0, 5);
+  log("\n📋 Example available tools:");
+  for (const tool of exampleTools) {
+    log(`  - ${tool.name}: ${tool.description}`);
+  }
+
+  if (dopplerTools.length > 5) {
+    log(`  ... and ${dopplerTools.length - 5} more tools`);
+  }
+
+  return { success: true, server };
 }
 
 async function createDopplerMCPServer(options: CLIOptions = {}) {
   verboseMode = options.verbose ?? false;
 
   try {
-    const validation = AuthManager.validateEnvironment();
-    if (!validation.valid) {
-      console.error("Environment validation failed:");
-      for (const error of validation.errors) {
-        console.error(`  - ${error}`);
-      }
-      console.error("\n" + AuthManager.getSetupInstructions());
-      process.exit(1);
-    }
-
     const specPath = path.join(__dirname, "..", "doppler-openapi.json");
     let openApiSpec: OpenAPISpec;
 
@@ -145,156 +306,39 @@ async function createDopplerMCPServer(options: CLIOptions = {}) {
       process.exit(1);
     }
 
-    const parser = new OpenAPIParser(openApiSpec);
-    const client = new DopplerClient();
+    const tokenCache = new TokenCache();
+    const cachedToken = await tokenCache.loadToken();
 
-    log("Testing Doppler API connection...");
-    const connectionTest = await client.testConnection();
-    if (!connectionTest.success) {
-      console.error("Failed to connect to Doppler API:", connectionTest.error);
-      console.error("\nPlease check your DOPPLER_TOKEN and try again.");
-      process.exit(1);
-    }
-    log("✓ Successfully connected to Doppler API");
+    if (cachedToken) {
+      const validation = AuthManager.validateToken(cachedToken.token);
+      if (!validation.valid) {
+        warn("Cached token appears invalid.");
+        await tokenCache.clearToken();
+        showAuthRequiredError();
+      }
 
-    // Detect token type early - needed to decide if auto-scope is safe
-    const token = process.env.DOPPLER_TOKEN ?? "";
-    const tokenType = detectTokenType(token);
+      const source = tokenCache.isFromEnvironment() ? "environment" : "keyring";
+      log(`Loaded token from ${source}`);
 
-    // Only auto-detect scope for service tokens (dp.st.*) which are genuinely
-    // scoped by Doppler. For other token types (service accounts, personal, etc.),
-    // seeing one project just means "workspace currently has one project" -
-    // creating another would change the scope unexpectedly.
-    const detectedScope =
-      tokenType === "service_token"
-        ? await detectImplicitScope(client)
-        : { project: undefined, config: undefined };
-
-    const cliScope = { project: options.project, config: options.config };
-    validateScope(detectedScope, cliScope);
-
-    const effectiveScope = mergeScope(detectedScope, cliScope);
-
-    if (detectedScope.project || detectedScope.config) {
-      const parts = [];
-      if (detectedScope.project)
-        parts.push(`project: ${detectedScope.project}`);
-      if (detectedScope.config) parts.push(`config: ${detectedScope.config}`);
-      log(`✓ Auto-detected scope: ${parts.join(", ")}`);
-    }
-
-    const scopeOptions = {
-      project: effectiveScope.project,
-      projectSource: options.project
-        ? "cli"
-        : detectedScope.project
-          ? "token"
-          : undefined,
-      config: effectiveScope.config,
-      configSource: options.config
-        ? "cli"
-        : detectedScope.config
-          ? "token"
-          : undefined,
-    } as const;
-
-    const generator = new ToolGenerator(client, scopeOptions);
-
-    log("Parsing OpenAPI specification...");
-    let dopplerTools = parser.parseToTools();
-
-    if (options.readOnly) {
-      dopplerTools = dopplerTools.filter((tool) => tool.method === "GET");
-      log(`✓ Filtered to ${dopplerTools.length} read-only endpoints`);
-    } else {
-      log(`✓ Parsed ${dopplerTools.length} API endpoints`);
-    }
-
-    if (effectiveScope.project) {
-      const beforeCount = dopplerTools.length;
-      dopplerTools = dopplerTools.filter(
-        (tool) =>
-          !ORG_LEVEL_ENDPOINT_PREFIXES.some((prefix) =>
-            tool.endpoint.startsWith(prefix),
-          ),
+      const result = await startAuthenticatedServer(
+        options,
+        openApiSpec,
+        cachedToken.token,
       );
-      log(
-        `✓ Filtered out org-level tools: ${beforeCount} → ${dopplerTools.length} endpoints`,
-      );
+
+      if (result.success) {
+        return result.server;
+      }
+
+      warn("Cached token is no longer valid.");
+      await tokenCache.clearToken();
+      showAuthRequiredError();
     }
 
-    if (effectiveScope.config) {
-      dopplerTools = dopplerTools.filter(
-        (tool) =>
-          tool.endpoint.includes("/configs/") ||
-          tool.name.includes("config") ||
-          tool.endpoint.includes("/secrets/") ||
-          tool.name.includes("secret"),
-      );
-      log(
-        `✓ Filtered for config-related tools: ${dopplerTools.length} endpoints`,
-      );
-    }
-
-    log("Generating MCP tools...");
-    const mcpTools = generator.generateTools(dopplerTools);
-    log(`✓ Generated ${mcpTools.length} MCP tools`);
-
-    const accessContext: AccessContext = {
-      tokenType,
-      readOnly: options.readOnly ?? false,
-      project: effectiveScope.project,
-      config: effectiveScope.config,
-    };
-    emitStartupMessages(accessContext);
-
-    const serverName = options.readOnly
-      ? "doppler-api-readonly"
-      : "doppler-api";
-    const server = new FastMCP({
-      name: serverName,
-      version: "1.0.0",
-    });
-
-    const confirmAccessTool = createConfirmAccessTool(accessContext);
-    if (confirmAccessTool) {
-      server.addTool(confirmAccessTool);
-    }
-
-    for (const tool of mcpTools) {
-      server.addTool(tool);
-    }
-
-    server.start({ transportType: "stdio" });
-
-    const modeText = options.readOnly ? " (Read-Only Mode)" : "";
-    log(`🚀 Doppler MCP Server started successfully!${modeText}`);
-    log(`📊 Available tools: ${mcpTools.length}`);
-    log(`🔗 Base URL: ${client.getBaseUrl()}`);
-
-    if (options.readOnly) {
-      log("🔒 Read-only mode: Only GET operations are available");
-    }
-    if (effectiveScope.project) {
-      log(`🎯 Project: ${effectiveScope.project}`);
-    }
-    if (effectiveScope.config) {
-      log(`🎯 Config: ${effectiveScope.config}`);
-    }
-
-    const exampleTools = dopplerTools.slice(0, 5);
-    log("\n📋 Example available tools:");
-    for (const tool of exampleTools) {
-      log(`  - ${tool.name}: ${tool.description}`);
-    }
-
-    if (dopplerTools.length > 5) {
-      log(`  ... and ${dopplerTools.length - 5} more tools`);
-    }
-
-    return server;
+    showAuthRequiredError();
   } catch (error) {
-    console.error("Failed to start Doppler MCP Server:", error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error("Failed to start Doppler MCP Server:", errorMessage);
     process.exit(1);
   }
 }
@@ -309,16 +353,139 @@ process.on("SIGTERM", () => {
   process.exit(0);
 });
 
-const options = parseCLIArgs();
+const isMainModule =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("doppler-mcp") ||
+  process.argv[1]?.endsWith("index.js");
 
-if (options.help) {
-  showHelp();
+async function handleLogin() {
+  const tokenCache = new TokenCache();
+
+  if (tokenCache.isFromEnvironment()) {
+    console.error("DOPPLER_TOKEN is set. Unset it to use interactive login.");
+    process.exit(1);
+  }
+
+  const { promptChoice, promptToken, copyToClipboard, openBrowser } =
+    await import("./prompt.js");
+
+  console.error("Doppler MCP Server - Login\n");
+
+  const choice = await promptChoice(
+    "How would you like to authenticate?",
+    ["Create new CLI token", "Enter a token manually"],
+    0,
+  );
+
+  if (choice === 1) {
+    const token = await promptToken();
+    if (token) {
+      const validation = AuthManager.validateToken(token);
+      if (!validation.valid) {
+        console.error("Invalid token format.");
+        process.exit(1);
+      }
+      await tokenCache.saveToken(token);
+      console.error("\n✓ Logged in. Token saved to system keyring.");
+      console.error("\nRun the server with: npx @dopplerhq/mcp-server");
+      process.exit(0);
+    }
+    console.error("No token provided.");
+    process.exit(1);
+  }
+
+  const baseUrl = process.env.DOPPLER_BASE_URL || "https://api.doppler.com";
+  const authCodeResponse = await generateAuthCode(baseUrl);
+  const authState = new DeviceAuthState(authCodeResponse, baseUrl);
+
+  const browserChoice = await promptChoice(
+    "Open the authorization page in your browser?",
+    ["Yes", "No"],
+    0,
+  );
+
+  if (browserChoice === 0) {
+    try {
+      await openBrowser(authState.authUrl);
+    } catch {}
+  }
+
+  console.error(`\nComplete authorization at ${authState.authUrl}`);
+  console.error(`Your auth code is:\n\x1b[32m${authState.code}\x1b[0m\n`);
+
+  try {
+    await copyToClipboard(authState.code);
+    console.error("(Copied to clipboard)");
+  } catch {}
+
+  console.error("\nWaiting for authentication...");
+
+  const token = await new Promise<string>((resolve, reject) => {
+    authState.startPolling(async (result) => {
+      resolve(result.token);
+    });
+
+    setTimeout(
+      () => reject(new Error("Authentication timed out")),
+      5 * 60 * 1000,
+    );
+  });
+
+  await tokenCache.saveToken(token);
+  console.error("\n✓ Logged in. Token saved to system keyring.");
+  console.error("\nRun the server with: npx @dopplerhq/mcp-server");
   process.exit(0);
 }
 
-createDopplerMCPServer(options).catch((error) => {
-  console.error("Fatal error:", error);
-  process.exit(1);
-});
+async function handleLogout() {
+  const tokenCache = new TokenCache();
+
+  if (tokenCache.isFromEnvironment()) {
+    console.error(
+      "Cannot logout: token is set via DOPPLER_TOKEN environment variable.",
+    );
+    console.error("Unset the environment variable to logout.");
+    process.exit(1);
+  }
+
+  await tokenCache.clearToken();
+  console.error("✓ Logged out. Cached credentials have been cleared.");
+  console.error(
+    "Your token has not been revoked. To revoke it, visit the Doppler dashboard.",
+  );
+  process.exit(0);
+}
+
+if (isMainModule) {
+  const options = parseCLIArgs();
+
+  if (options.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  if (options.command === "login") {
+    handleLogin().catch((error) => {
+      console.error(
+        "Login failed:",
+        error instanceof Error ? error.message : String(error),
+      );
+      process.exit(1);
+    });
+  } else if (options.command === "logout") {
+    handleLogout().catch((error) => {
+      console.error(
+        "Logout failed:",
+        error instanceof Error ? error.message : String(error),
+      );
+      process.exit(1);
+    });
+  } else {
+    createDopplerMCPServer(options).catch((error) => {
+      console.error("Fatal error:", error);
+      process.exit(1);
+    });
+  }
+}
 
 export { createDopplerMCPServer };

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,0 +1,142 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+import * as readline from "readline";
+
+const execAsync = promisify(exec);
+
+export async function promptChoice(
+  question: string,
+  options: string[],
+  defaultIndex: number = 0,
+): Promise<number> {
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      "Not authenticated. Run 'npx @dopplerhq/mcp-server login' first, or set DOPPLER_TOKEN environment variable.",
+    );
+  }
+
+  return new Promise((resolve) => {
+    let selectedIndex = defaultIndex;
+    let renderCount = 0;
+
+    const renderOptions = () => {
+      if (renderCount > 0) {
+        process.stderr.write(`\x1b[${options.length}A`);
+      }
+      renderCount++;
+
+      options.forEach((opt, i) => {
+        const marker = i === selectedIndex ? "❯" : " ";
+        const highlight = i === selectedIndex ? "\x1b[36m" : "\x1b[90m";
+        process.stderr.write(`\x1b[2K  ${marker} ${highlight}${opt}\x1b[0m\n`);
+      });
+    };
+
+    const cleanup = () => {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+      process.stderr.write("\x1b[?25h");
+      process.stdin.removeListener("data", onKeyPress);
+    };
+
+    const onKeyPress = (key: string) => {
+      if (key === "\x03") {
+        cleanup();
+        process.exit(0);
+      }
+
+      if (key === "\r" || key === "\n") {
+        cleanup();
+        process.stderr.write("\n");
+        resolve(selectedIndex);
+        return;
+      }
+
+      if (key === "\x1b[A" || key === "k") {
+        selectedIndex = (selectedIndex - 1 + options.length) % options.length;
+        renderOptions();
+      } else if (key === "\x1b[B" || key === "j") {
+        selectedIndex = (selectedIndex + 1) % options.length;
+        renderOptions();
+      }
+    };
+
+    process.stderr.write(`${question}\n`);
+    renderOptions();
+    process.stderr.write("\x1b[?25l");
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", onKeyPress);
+  });
+}
+
+export async function promptToken(): Promise<string | undefined> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+
+  return new Promise((resolve) => {
+    process.stderr.write("Enter your Doppler token: ");
+
+    rl.on("line", (answer) => {
+      rl.close();
+      const token = answer.trim();
+      resolve(token || undefined);
+    });
+  });
+}
+
+export async function copyToClipboard(text: string): Promise<void> {
+  const escaped = text.replace(/"/g, '\\"');
+
+  switch (process.platform) {
+    case "darwin":
+      await execAsync(`printf '%s' "${escaped}" | pbcopy`);
+      break;
+    case "linux":
+      await tryCommands([
+        `printf '%s' "${escaped}" | xclip -selection clipboard`,
+        `printf '%s' "${escaped}" | xsel --clipboard --input`,
+      ]);
+      break;
+    case "win32":
+      await execAsync(`echo|set /p="${text}" | clip`);
+      break;
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}
+
+async function tryCommands(commands: string[]): Promise<void> {
+  for (let i = 0; i < commands.length; i++) {
+    try {
+      await execAsync(commands[i]);
+      return;
+    } catch {
+      if (i === commands.length - 1) throw new Error("All commands failed");
+    }
+  }
+}
+
+export async function openBrowser(url: string): Promise<void> {
+  switch (process.platform) {
+    case "darwin":
+      await execAsync(`open "${url}"`);
+      break;
+    case "linux":
+      await tryCommands([
+        `xdg-open "${url}"`,
+        `sensible-browser "${url}"`,
+        `x-www-browser "${url}"`,
+      ]);
+      break;
+    case "win32":
+      await execAsync(`start "" "${url}"`);
+      break;
+    default:
+      throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+}

--- a/src/token-cache.ts
+++ b/src/token-cache.ts
@@ -1,0 +1,105 @@
+const KEYRING_SERVICE = "doppler-mcp-server";
+const KEYRING_ACCOUNT = "token";
+
+interface KeyringEntry {
+  getPassword(): string | null;
+  setPassword(password: string): void;
+  deletePassword(): void;
+}
+
+interface KeyringModule {
+  Entry: new (service: string, account: string) => KeyringEntry;
+}
+
+let keyringModule: KeyringModule | null = null;
+let keyringLoadAttempted = false;
+
+async function getKeyring(): Promise<KeyringModule | null> {
+  if (keyringLoadAttempted) {
+    return keyringModule;
+  }
+  keyringLoadAttempted = true;
+
+  try {
+    const moduleName = "@napi-rs/keyring";
+    keyringModule = (await import(moduleName)) as KeyringModule;
+    return keyringModule;
+  } catch {
+    return null;
+  }
+}
+
+export interface CachedToken {
+  token: string;
+  apiHost: string;
+}
+
+export class TokenCache {
+  async loadToken(): Promise<CachedToken | undefined> {
+    const envToken = process.env.DOPPLER_TOKEN;
+    if (envToken) {
+      return {
+        token: envToken,
+        apiHost: process.env.DOPPLER_BASE_URL || "https://api.doppler.com",
+      };
+    }
+
+    const keyring = await getKeyring();
+    if (keyring) {
+      try {
+        const entry = new keyring.Entry(KEYRING_SERVICE, KEYRING_ACCOUNT);
+        const token = entry.getPassword();
+        if (token) {
+          return {
+            token,
+            apiHost: process.env.DOPPLER_BASE_URL || "https://api.doppler.com",
+          };
+        }
+      } catch (error) {
+        console.error(
+          "Warning: Could not access system keyring:",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+
+    return undefined;
+  }
+
+  async saveToken(token: string): Promise<void> {
+    const keyring = await getKeyring();
+    if (!keyring) {
+      console.error(
+        "Warning: System keyring not available. Token will not persist across sessions.",
+      );
+      return;
+    }
+
+    try {
+      const entry = new keyring.Entry(KEYRING_SERVICE, KEYRING_ACCOUNT);
+      entry.setPassword(token);
+    } catch (error) {
+      console.error(
+        "Warning: Could not save token to system keyring:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  async clearToken(): Promise<void> {
+    const keyring = await getKeyring();
+    if (!keyring) {
+      return;
+    }
+
+    try {
+      const entry = new keyring.Entry(KEYRING_SERVICE, KEYRING_ACCOUNT);
+      entry.deletePassword();
+    } catch {
+    }
+  }
+
+  isFromEnvironment(): boolean {
+    return !!process.env.DOPPLER_TOKEN;
+  }
+}


### PR DESCRIPTION
Currently, the way to authenticate the MCP server with Doppler requires hardcoding a DOPPLER_TOKEN env var somewhere. This PR adds device code authentication to create and cache CLI tokens, or cache manually entered tokens so that users don't need to declare them as env vars.

Specifically, it 
  - Adds a `login` command for browser-based device code authentication in the same vein as our CLI.
  - Adds a `logout` command to clear those cached credentials
  - Store tokens securely in system keyring
  - Keeps DOPPLER_TOKEN env var support

[Watch the Loom Video Here](https://www.loom.com/share/2c916631d1ee4671b64032c3155c543b)

Closes ENG-9136
Should be merged along with https://github.com/DopplerHQ/server/pull/7571