### PR TITLE
Fix OpenAPI spec file path resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "files": [
     "dist/",
     "bin/",
+    "doppler-openapi.json",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Currently, the OpenAPI spec is copied into `dist/` during build, but the runtime path resolves to the parent directory. Users installing/running with npm/npx get a missing file error since only `dist/` is published.

This PR fixes that.